### PR TITLE
Develop the CompoundAgent contract

### DIFF
--- a/contracts/CompoundAgent.sol
+++ b/contracts/CompoundAgent.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
+import { CompoundAgentStorage } from "./CompoundAgentStorage.sol";
+import { ICompoundAgent } from "./interfaces/ICompoundAgent.sol";
+import { IERC20Mintable } from "./interfaces/IERC20Mintable.sol";
+import { IComptroller } from "./interfaces/IComptroller.sol";
+import { ICToken } from "./interfaces/ICToken.sol";
+
+/**
+ * @title CompoundAgent contract
+ * @author CloudWalk Inc.
+ * @dev Compound operations wrapper contract.
+ */
+contract CompoundAgent is
+    Initializable,
+    OwnableUpgradeable,
+    PausableExtUpgradeable,
+    CompoundAgentStorage,
+    ICompoundAgent
+{
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @dev Emitted when an admin account is configured.
+     * @param account The address of the admin account.
+     * @param newStatus The new status of the admin account.
+     */
+    event ConfigureAdmin(address indexed account, bool newStatus);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev An admin account is already configured.
+    error AdminAlreadyConfigured();
+
+    /// @dev The transaction sender is not an admin.
+    error UnauthorizedAdmin();
+
+    /// @dev The amount to redeem equals zero.
+    error ZeroRedeemAmount();
+
+    /// @dev Token minting failed.
+    error MintFailure();
+
+    /// @dev The length of the input arrays does not match.
+    error InputArraysLengthMismatch();
+
+    /**
+     * @dev An error occurred on the Compound market.
+     * @param compError The code of the error that occurred.
+     */
+    error CompoundMarketFailure(uint256 compError);
+
+    /**
+     * @dev An error occurred on the Compound comptroller.
+     * @param compError The code of the error that occurred.
+     */
+    error CompoundComptrollerFailure(uint256 compError);
+
+    /// @dev A new owner is the same as previously set one.
+    error OwnerUnchanged();
+
+    // -------------------- Modifiers -----------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the admin.
+     */
+    modifier onlyAdmin() {
+        if (!_admins[_msgSender()]) {
+            revert UnauthorizedAdmin();
+        }
+        _;
+    }
+
+    // -------------------- Functions -----------------------------------
+
+    /**
+     * @dev Constructor that prohibits the initialization of the implementation of the upgradable contract.
+     *
+     * See details
+     * https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+     *
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev The initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
+     *
+     * @param market_ The address of the market contract.
+     */
+    function initialize(address market_) external initializer {
+        __CompoundAgent_init(market_);
+    }
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See {CompoundAgent-initialize}.
+     *
+     * @param market_ The address of the market contract.
+     */
+    function __CompoundAgent_init(address market_) internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+        __PausableExt_init_unchained();
+
+        __CompoundAgent_init_unchained(market_);
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {CompoundAgent-initialize}.
+     *
+     * @param market_ The address of the market contract.
+     */
+    function __CompoundAgent_init_unchained(address market_) internal onlyInitializing {
+        address[] memory cTokens = new address[](1);
+        cTokens[0] = market_;
+        uint256[] memory enterMarketResults = IComptroller(ICToken(market_).comptroller()).enterMarkets(cTokens);
+        if (enterMarketResults[0] != 0) {
+            revert CompoundComptrollerFailure(enterMarketResults[0]);
+        }
+
+        IERC20Upgradeable uToken = IERC20Upgradeable(ICToken(market_).underlying());
+        uToken.approve(owner(), type(uint256).max);
+        uToken.approve(market_, type(uint256).max);
+
+        _market = market_;
+    }
+
+    /**
+     * @dev See {ICompoundAgent-mint}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     * - The contract must not be paused.
+     */
+    function mint(uint256 mintAmount) public override onlyOwner whenNotPaused {
+        uint256 result = ICToken(_market).mint(mintAmount);
+        if (result != 0) {
+            revert CompoundMarketFailure(result);
+        }
+    }
+
+    /**
+     * @dev See {ICompoundAgent-redeem}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     * - The contract must not be paused.
+     */
+    function redeem(uint256 redeemAmount) external override onlyOwner whenNotPaused {
+        uint256 result = ICToken(_market).redeem(redeemAmount);
+        if (result != 0) {
+            revert CompoundMarketFailure(result);
+        }
+    }
+
+    /**
+     * @dev See {ICompoundAgent-redeemUnderlying}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     * - The contract must not be paused.
+     */
+    function redeemUnderlying(uint256 redeemAmount) public override onlyOwner whenNotPaused {
+        uint256 result = ICToken(_market).redeemUnderlying(redeemAmount);
+        if (result != 0) {
+            revert CompoundMarketFailure(result);
+        }
+    }
+
+    /**
+     * @dev See {ICompoundAgent-repayTrustedBorrow}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     */
+    function repayTrustedBorrow(
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) external onlyAdmin whenNotPaused {
+        ICToken cToken = ICToken(_market);
+        IERC20Mintable uToken = IERC20Mintable(cToken.underlying());
+        _repayTrustedBorrow(cToken, uToken, borrower, repayAmount, defaulted);
+    }
+
+    /**
+     * @dev See {ICompoundAgent-repayTrustedBorrows}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     */
+    function repayTrustedBorrows(
+        address[] calldata borrowers,
+        uint256[] calldata repayAmounts,
+        bool[] calldata defaulted
+    ) external onlyAdmin whenNotPaused {
+        uint256 len = borrowers.length;
+        if (len != repayAmounts.length || len != defaulted.length) {
+            revert InputArraysLengthMismatch();
+        }
+
+        ICToken cToken = ICToken(_market);
+        IERC20Mintable uToken = IERC20Mintable(cToken.underlying());
+
+        for (uint256 i = 0; i < len; ++i) {
+            _repayTrustedBorrow(cToken, uToken, borrowers[i], repayAmounts[i], defaulted[i]);
+        }
+    }
+
+    /**
+     * @dev Configures an admin.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     *
+     * Emits a {ConfigureAdmin} event.
+     *
+     * @param account The address of the admin account.
+     * @param newStatus The new status of the admin account.
+     */
+    function configureAdmin(address account, bool newStatus) external onlyOwner {
+        if (_admins[account] == newStatus) {
+            revert AdminAlreadyConfigured();
+        }
+
+        _admins[account] = newStatus;
+
+        emit ConfigureAdmin(account, newStatus);
+    }
+
+    /**
+     * @dev See {ICompoundAgent-isAdmin}.
+     */
+    function isAdmin(address account) external view returns (bool) {
+        return _admins[account];
+    }
+
+    /**
+     * @dev See {ICompoundAgent-market}.
+     */
+    function market() external view returns (address) {
+        return _market;
+    }
+
+    /**
+     * @dev Overrides the {OwnableUpgradeable-transferOwnership} function.
+     *
+     * Executes the `transferOwnership` function from the base `OwnableUpgradeable` contract
+     * and updates the allowance for old and new owners on the underlying token after that.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     *
+     * @param newOwner The address of the new contract owner.
+     */
+    function transferOwnership(address newOwner) public override onlyOwner {
+        address oldOwner = owner();
+        if (oldOwner == newOwner) {
+            revert OwnerUnchanged();
+        }
+
+        OwnableUpgradeable.transferOwnership(newOwner);
+
+        IERC20Upgradeable uToken = IERC20Upgradeable(ICToken(_market).underlying());
+        uToken.approve(oldOwner, 0);
+        uToken.approve(newOwner, type(uint256).max);
+    }
+
+    /**
+     * @dev Repays a borrow belonging to a trusted borrower.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     * Emits a {RepayDefaultedBorrow} event in the case of a defaulted borrow.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @param defaulted True if the borrow is defaulted.
+     */
+    function _repayTrustedBorrow(
+        ICToken cToken,
+        IERC20Mintable uToken,
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) internal {
+        uint256 repaidAmount = _mintAndRepay(cToken, uToken, borrower, repayAmount);
+        if (defaulted) {
+            _redeemAndBurn(cToken, uToken, borrower, repaidAmount);
+        }
+    }
+
+    /**
+     * @dev Mints tokens and repays a borrow on behalf of a trusted borrower.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower being repaid.
+     * @param repayAmount The amount of tokens to repay.
+     */
+    function _mintAndRepay(
+        ICToken cToken,
+        IERC20Mintable uToken,
+        address borrower,
+        uint256 repayAmount
+    ) internal returns (uint256 actualRepayAmount) {
+        actualRepayAmount = repayAmount == type(uint256).max
+            ? repayAmount = cToken.borrowBalanceCurrent(borrower)
+            : repayAmount;
+
+        if (!uToken.mint(address(this), actualRepayAmount)) {
+            revert MintFailure();
+        }
+
+        uint256 repayResult = cToken.repayBorrowBehalf(borrower, actualRepayAmount);
+        if (repayResult != 0) {
+            revert CompoundMarketFailure(repayResult);
+        }
+
+        emit RepayTrustedBorrow(borrower, actualRepayAmount);
+    }
+
+    /**
+     * @dev Redeems and burns tokens when a defaulted borrow is being repaid.
+     *
+     * Emits a {RepayDefaultedBorrow} event.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower being repaid.
+     * @param burnAmount The amount of tokens to burn.
+     */
+    function _redeemAndBurn(
+        ICToken cToken,
+        IERC20Mintable uToken,
+        address borrower,
+        uint256 burnAmount
+    ) internal {
+        uint256 redeemResult = cToken.redeemUnderlying(burnAmount);
+        if (redeemResult != 0) {
+            revert CompoundMarketFailure(redeemResult);
+        }
+
+        uToken.burn(burnAmount);
+
+        emit RepayDefaultedBorrow(borrower, burnAmount);
+    }
+}

--- a/contracts/CompoundAgentStorage.sol
+++ b/contracts/CompoundAgentStorage.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CompoundAgent storage version 1
+ * @author CloudWalk Inc.
+ */
+abstract contract CompoundAgentStorageV1 {
+    /// @dev The address of the Compound market.
+    address internal _market;
+
+    /// @dev The mapping of an admin status for a given address.
+    mapping(address => bool) internal _admins;
+}
+
+/**
+ * @title CompoundAgent storage
+ *
+ * We are following Compound's approach of upgrading new contract implementations.
+ * See https://github.com/compound-finance/compound-protocol.
+ * When we need to add new storage variables, we create a new version of CompoundAgent
+ * e.g. CompoundAgentStorage<versionNumber>, so finally it would look like
+ * "contract CompoundAgentStorage is CompoundAgentStorageV1, CompoundAgentStorageV2".
+ */
+abstract contract CompoundAgentStorage is CompoundAgentStorageV1 {
+
+}

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+/**
+ * @title PausableExtUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Extends the {PausableUpgradeable} contract by adding the `pauser` role.
+ *
+ * This contract is used through inheritance. It introduces the `pauser` role that is allowed
+ * to trigger paused/unpaused state of the contract that is inherited from this one.
+ *
+ * By default, the pauser is to the zero address. This can later be changed
+ * by the contract owner with the {setPauser} function.
+ */
+abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradeable {
+    /// @dev The address of the pauser.
+    address private _pauser;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the pauser is changed.
+    event PauserChanged(address indexed pauser);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The transaction sender is not a pauser.
+    error UnauthorizedPauser(address account);
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
+     */
+    function __PausableExt_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+
+        __PausableExt_init_unchained();
+    }
+
+    /**
+     * @dev The internal unchained initializer of the upgradable contract.
+     *
+     * See {PausableExtUpgradeable-__PausableExt_init}.
+     */
+    function __PausableExt_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Throws if called by any account other than the pauser.
+     */
+    modifier onlyPauser() {
+        if (_msgSender() != _pauser) {
+            revert UnauthorizedPauser(_msgSender());
+        }
+        _;
+    }
+
+    /**
+     * @dev Returns the pauser address.
+     */
+    function pauser() public view virtual returns (address) {
+        return _pauser;
+    }
+
+    /**
+     * @dev Updates the pauser address.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner.
+     *
+     * Emits a {PauserChanged} event.
+     *
+     * @param newPauser The address of a new pauser.
+     */
+    function setPauser(address newPauser) external onlyOwner {
+        if (_pauser == newPauser) {
+            return;
+        }
+
+        _pauser = newPauser;
+
+        emit PauserChanged(_pauser);
+    }
+
+    /**
+     * @dev See {PausableUpgradeable-pause}.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function pause() external onlyPauser {
+        _pause();
+    }
+
+    /**
+     * @dev See {PausableUpgradeable-unpause}.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function unpause() external onlyPauser {
+        _unpause();
+    }
+}

--- a/contracts/interfaces/ICToken.sol
+++ b/contracts/interfaces/ICToken.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title ICToken interface
+ * @author CloudWalk Inc.
+ * @dev The interface of the Compound protocol market.
+ */
+interface ICToken {
+    /**
+     * @dev Supplies underlying asset tokens into the market and receives cTokens in exchange.
+     * @param mintAmount The amount of the underlying asset tokens to supply.
+     * @return 0=success, otherwise a failure.
+     */
+    function mint(uint256 mintAmount) external returns (uint256);
+
+    /**
+     * @dev Redeems cTokens in exchange for the underlying asset tokens.
+     * @param redeemTokens The amount of cTokens to redeem.
+     * @return 0=success, otherwise a failure.
+     */
+    function redeem(uint256 redeemTokens) external returns (uint256);
+
+    /**
+     * @dev Redeems cTokens in exchange for a specified amount of underlying asset tokens.
+     * @param redeemAmount The amount of underlying asset tokens to redeem.
+     * @return 0=success, otherwise a failure.
+     */
+    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
+
+    /**
+     * @dev Repays a borrow belonging to the borrower.
+     * @param borrower The account with the debt being payed off.
+     * @param repayAmount The amount to repay (-1 for the full outstanding amount).
+     * @return 0=success, otherwise a failure.
+     */
+    function repayBorrowBehalf(address borrower, uint256 repayAmount) external returns (uint256);
+
+    /**
+     * @dev Accrues interest and then calculates the account's borrow balance.
+     * @param account The address whose balance should be calculated.
+     * @return The calculated borrow balance.
+     */
+    function borrowBalanceCurrent(address account) external returns (uint256);
+
+    /**
+     * @dev Returns the address of the comptroller contract.
+     */
+    function comptroller() external view returns (address);
+
+    /**
+     * @dev Returns the address of the underlying token.
+     */
+    function underlying() external view returns (address);
+}

--- a/contracts/interfaces/ICompoundAgent.sol
+++ b/contracts/interfaces/ICompoundAgent.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CompoundAgent interface
+ * @author CloudWalk Inc.
+ * @dev The interface of the Compound operations wrapper contract.
+ */
+interface ICompoundAgent {
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @dev Emitted when a trusted borrow is repaid.
+     * @param account The address of the trusted borrower.
+     * @param repayAmount The amount of tokens being repaid.
+     */
+    event RepayTrustedBorrow(address indexed account, uint256 repayAmount);
+
+    /**
+     * @dev Emitted when a defaulted borrow is repaid.
+     * @param account The address of the trusted borrower.
+     * @param burnAmount The amount of tokens being burned.
+     */
+    event RepayDefaultedBorrow(address indexed account, uint256 burnAmount);
+
+    // -------------------- Functions -----------------------------------
+
+    /**
+     * @dev Supplies underlying asset tokens into the market and receives cTokens in exchange.
+     * @param mintAmount The amount of underlying asset tokens to supply.
+     */
+    function mint(uint256 mintAmount) external;
+
+    /**
+     * @dev Redeems cTokens from the market in exchange for underlying asset tokens.
+     * @param redeemTokens The amount of cTokens to redeem.
+     */
+    function redeem(uint256 redeemTokens) external;
+
+    /**
+     * @dev Redeems cTokens from the market in exchange for underlying asset tokens.
+     * @param redeemAmount The amount of underlying asset tokens to redeem.
+     */
+    function redeemUnderlying(uint256 redeemAmount) external;
+
+    /**
+     * @dev Repays a borrow belonging to a trusted borrower.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     * Emits a {RepayDefaultedBorrow} event in the case of a defaulted borrow.
+     *
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @param defaulted True if the borrow is defaulted.
+     */
+    function repayTrustedBorrow(
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) external;
+
+    /**
+     * @dev Repays borrows belonging to trusted borrowers.
+     *
+     * If the borrow is defaulted along with the repayment redeems the corresponding amount of cTokens
+     * and burns the underlying tokens gotten in exchange.
+     *
+     * The provided amount of tokens can exceed the remaining amount of the loan.
+     * In this case, only the amount of tokens required to complete the loan will be used.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     * Emits a {BurnDefaultedBorrow} event if the `defaulted` argument is true.
+     *
+     * @param borrowers An array of addresses of verified borrowers.
+     * @param repayAmounts An array of token amounts to repay.
+     * @param defaulted An array of defaulted borrows.
+     */
+    function repayTrustedBorrows(
+        address[] calldata borrowers,
+        uint256[] calldata repayAmounts,
+        bool[] calldata defaulted
+    ) external;
+
+    /**
+     * @dev Checks if the account is configured as a contract administrator.
+     */
+    function isAdmin(address account) external view returns (bool);
+
+    /**
+     * @dev Returns the address of the market contract.
+     */
+    function market() external view returns (address);
+}

--- a/contracts/interfaces/IComptroller.sol
+++ b/contracts/interfaces/IComptroller.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title IComptroller interface
+ * @author CloudWalk Inc.
+ * @dev The interface of the Compound protocol comptroller.
+ */
+interface IComptroller {
+    /**
+     * @dev Adds assets to be included in account liquidity calculation.
+     * @param cTokens The list of addresses of the cToken markets to be enabled.
+     * @return Success indicator for whether each corresponding market was entered.
+     */
+    function enterMarkets(address[] memory cTokens) external returns (uint256[] memory);
+}

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title IERC20Mintable interface
+ * @author CloudWalk Inc.
+ * @dev The interface of a token that supports mint and burn operations.
+ */
+interface IERC20Mintable {
+    /**
+     * @dev Mints tokens.
+     * @param account The address of a tokens recipient.
+     * @param amount The amount of tokens to mint.
+     * @return True if the operation was successful.
+     */
+    function mint(address account, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Burns tokens.
+     * @param amount The amount of tokens to burn.
+     */
+    function burn(uint256 amount) external;
+}

--- a/contracts/mock/CTokenMock.sol
+++ b/contracts/mock/CTokenMock.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { ICToken } from "../interfaces/ICToken.sol";
+
+/**
+ * @title CTokenMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {ICToken} interface for test purposes.
+ */
+contract CTokenMock is ICToken {
+    /// @dev The address of the comptroller contract.
+    address private _comptroller;
+
+    /// @dev The address of the underlying token.
+    address private _underlyingToken;
+
+    /// @dev The result of the `mint()` function.
+    uint256 private _mintResult;
+
+    /// @dev The result of the `redeem()` function.
+    uint256 private _redeemResult;
+
+    /// @dev The result of the `redeemUnderlying()` function.
+    uint256 private _redeemUnderlyingResult;
+
+    /// @dev The result of the `repayBorrowBehalf()` function.
+    uint256 private _repayBorrowBehalfResult;
+
+    /// @dev The result of the `borrowBalanceCurrent()` function.
+    uint256 private _borrowBalanceCurrentResult;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the `mint()` function is executed. Contains the argument of the function.
+    event CTokenMockMint(uint256 amount);
+
+    /// @dev Emitted when the `redeem()` function is executed. Contains the argument of the function.
+    event CTokenMockRedeem(uint256 amount);
+
+    /// @dev Emitted when the `redeemUnderlying()` function is executed. Contains the argument of the function.
+    event CTokenMockRedeemUnderlying(uint256 amount);
+
+    /// @dev Emitted when the `repayBorrowBehalf()` function is executed. Contains the arguments of the function.
+    event CTokenMockRepayBorrowBehalf(address borrower, uint256 actualRepayAmount);
+
+    /// @dev Emitted when the `borrowBalanceCurrent()` function is executed. Contains the argument of the function.
+    event CTokenMockBorrowBalanceCurrent(address borrower);
+
+    // -------------------- Functions --------------------------------
+
+    /// @dev Initializes the contract with the provided addresses of the comptroller and underlying token.
+    constructor(address comptroller_, address underlyingToken_) {
+        _comptroller = comptroller_;
+        _underlyingToken = underlyingToken_;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-mint} function with emitting the corresponding event.
+     * @param amount The amount of tokens to mint.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function mint(uint256 amount) external returns (uint256) {
+        emit CTokenMockMint(amount);
+        return _mintResult;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-redeem} function with emitting the corresponding event.
+     * @param amount The amount of tokens to redeem.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function redeem(uint256 amount) external returns (uint256) {
+        emit CTokenMockRedeem(amount);
+        return _redeemResult;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-redeemUnderlying} function with emitting the corresponding event.
+     * @param amount The amount of underlying tokens to redeem.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function redeemUnderlying(uint256 amount) external returns (uint256) {
+        emit CTokenMockRedeemUnderlying(amount);
+        return _redeemUnderlyingResult;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-repayBorrowBehalf} function with emitting the corresponding event.
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function repayBorrowBehalf(address borrower, uint256 repayAmount) external returns (uint256) {
+        emit CTokenMockRepayBorrowBehalf(borrower, repayAmount);
+        return _repayBorrowBehalfResult;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-borrowBalanceCurrent} function with emitting the corresponding event.
+     * @param borrower The address of the borrower.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function borrowBalanceCurrent(address borrower) external returns (uint256) {
+        emit CTokenMockBorrowBalanceCurrent(borrower);
+        return _borrowBalanceCurrentResult;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-comptroller} function.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function comptroller() external view returns (address) {
+        return _comptroller;
+    }
+
+    /**
+     * @dev Simulates the call of the {ICToken-underlying} function.
+     * @return The value of the corresponding storage variable previously set to the contract.
+     */
+    function underlying() external view returns (address) {
+        return _underlyingToken;
+    }
+
+    /// @dev Sets the result of the `mint()` function in the corresponding storage variable.
+    function setMintResult(uint256 newResult) external {
+        _mintResult = newResult;
+    }
+
+    /// @dev Sets the result of the `redeem()` function in the corresponding storage variable.
+    function setRedeemResult(uint256 newResult) external {
+        _redeemResult = newResult;
+    }
+
+    /// @dev Sets the result of the `redeemUnderlying()` function in the corresponding storage variable.
+    function setRedeemUnderlyingResult(uint256 newResult) external {
+        _redeemUnderlyingResult = newResult;
+    }
+
+    /// @dev Sets the result of the `repayBorrowBehalf()` function in the corresponding storage variable.
+    function setRepayBorrowBehalfResult(uint256 newResult) external {
+        _repayBorrowBehalfResult = newResult;
+    }
+
+    /// @dev Sets the result of the `borrowBalanceCurrent()` function in the corresponding storage variable.
+    function setBorrowBalanceCurrentResult(uint256 newResult) external {
+        _borrowBalanceCurrentResult = newResult;
+    }
+}

--- a/contracts/mock/ComptrollerMock.sol
+++ b/contracts/mock/ComptrollerMock.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IComptroller } from "../interfaces/IComptroller.sol";
+
+/**
+ * @title ComptrollerMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {IComptroller} interface for test purposes.
+ */
+contract ComptrollerMock is IComptroller {
+    /// @dev The result of the `enterMarkets()` function.
+    uint256 private _enterMarketsResult;
+
+    /**
+     * @dev Emitted when the `enterMarkets()` function is executed.
+     * @param firstMarket The address of the first market in the input array of the `enterMarkets()` function.
+     * @param marketCount The number of markets in the input array of the `enterMarkets()` function.
+     */
+    event EnterMarkets(address firstMarket, uint256 marketCount);
+
+    /**
+     * @dev Simulates the call of the {IComptroller-enterMarkets} function with emitting the corresponding event.
+     * @param cTokens The list of market addresses.
+     * @return The array of copies of the corresponding storage variable.
+     */
+    function enterMarkets(address[] memory cTokens) external returns (uint256[] memory) {
+        uint256 len = cTokens.length;
+        uint256 result = _enterMarketsResult;
+        uint256[] memory results = new uint256[](len);
+
+        emit EnterMarkets(cTokens[0], len);
+
+        for (uint256 i = 0; i < len; ++i) {
+            results[i] = result;
+        }
+
+        return results;
+    }
+
+    /// @dev Sets the result of the `enterMarkets()` function in the corresponding storage variable.
+    function setEnterMarketsResult(uint256 result) external {
+        _enterMarketsResult = result;
+    }
+}

--- a/contracts/mock/ERC20MintableMock.sol
+++ b/contracts/mock/ERC20MintableMock.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20Mintable } from "../interfaces/IERC20Mintable.sol";
+
+/**
+ * @title ERC20MintableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {ERC20} contract with minting and burning possibilities for test purposes.
+ */
+contract ERC20MintableMock is ERC20, IERC20Mintable {
+    /// @dev The disable state of the `mint()` function.
+    bool private _mintDisabled;
+
+    /// @dev Emitted when the `mint()` function is executed. Contains the arguments of the function.
+    event ERC20MockMint(address account, uint256 amount);
+
+    /// @dev Emitted when the `burn()` function is executed. Contains the argument of the function.
+    event ERC20MockBurn(uint256 amount);
+
+    /// @dev Initializes the contract with the provided name and symbol of the token.
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    /**
+     * @dev Simulates the call of the {IERC20Mintable-mint} function with emitting the corresponding event.
+     * @param amount The amount of tokens to mint.
+     * @return True if the `mint()` function is not disabled.
+     */
+    function mint(address account, uint256 amount) external returns (bool) {
+        emit ERC20MockMint(account, amount);
+        return _mintDisabled ? false : true;
+    }
+
+    /**
+     * @dev Simulates the call of the {IERC20Mintable-burn} function with emitting the corresponding event.
+     * @param amount The amount of tokens to burn.
+     */
+    function burn(uint256 amount) external {
+        emit ERC20MockBurn(amount);
+    }
+
+    /// @dev Disables the `mint()` function.
+    function disableMint() external {
+        _mintDisabled = true;
+    }
+}

--- a/contracts/mock/base/PausableExtUpgradeableMock.sol
+++ b/contracts/mock/base/PausableExtUpgradeableMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { PausableExtUpgradeable } from "../../base/PausableExtUpgradeable.sol";
+
+/**
+ * @title PausableExtUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {PausableExtUpgradeable} contract for test purposes.
+ */
+contract PausableExtUpgradeableMock is PausableExtUpgradeable {
+    /**
+     * @dev The initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
+     */
+    function initialize() public initializer {
+        __PausableExt_init();
+    }
+
+    /**
+     * @dev Needed to check that the internal initializer of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_init() public {
+        __PausableExt_init();
+    }
+
+    /**
+     * @dev Needed to check that the internal unchained initializer of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_init_unchained() public {
+        __PausableExt_init_unchained();
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
+        "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
         "@openzeppelin/hardhat-upgrades": "^1.20.0",
         "@types/chai": "^4.3.3",
@@ -1356,6 +1357,12 @@
       "peerDependencies": {
         "hardhat": "^2.0.4"
       }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "dev": true
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "4.7.3",
@@ -12615,6 +12622,12 @@
         "table": "^6.8.0",
         "undici": "^5.4.0"
       }
+    },
+    "@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==",
+      "dev": true
     },
     "@openzeppelin/contracts-upgradeable": {
       "version": "4.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
+    "@openzeppelin/contracts": "^4.7.3",
     "@openzeppelin/contracts-upgradeable": "^4.7.3",
     "@openzeppelin/hardhat-upgrades": "^1.20.0",
     "@types/chai": "^4.3.3",

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -1,0 +1,3 @@
+## Test utils directory
+
+This directory contains some custom utilities used in the tests

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,0 +1,6 @@
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+
+export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
+  const txReceipt = await txResponsePromise;
+  return txReceipt.wait();
+}

--- a/test/CompoundAgent.test.ts
+++ b/test/CompoundAgent.test.ts
@@ -1,0 +1,766 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../test-utils/eth";
+
+interface HelperContracts {
+  comptroller: Contract,
+  cToken: Contract,
+  uToken: Contract
+}
+
+interface AllContracts {
+  agent: Contract,
+  comptroller: Contract,
+  cToken: Contract,
+  uToken: Contract
+}
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'CompoundAgent'", function () {
+  const TOKEN_AMOUNT_STUB = 123;
+
+  const MARKET_MINT_FUNCTION_BAD_RESULT = 12301;
+  const MARKET_REDEEM_FUNCTION_BAR_RESULT = 12302;
+  const MARKET_REDEEM_UNDERLYING_BAD_RESULT = 12303;
+  const MARKET_REPAY_BORROW_BEHALF_BAD_RESULT = 12304;
+  const COMPTROLLER_ENTER_MARKET_BAD_RESULT = 12305;
+
+  const BORROW_IS_DEFAULTED = true;
+  const BORROW_IS_NOT_DEFAULTED = false;
+
+  const EVENT_NAME_CONFIGURE_ADMIN = "ConfigureAdmin";
+  const EVENT_NAME_REPAY_TRUSTED_BORROW = "RepayTrustedBorrow";
+  const EVENT_NAME_REPAY_DEFAULTED_BORROW = "RepayDefaultedBorrow";
+  const EVENT_NAME_OWNERSHIP_TRANSFERRED = "OwnershipTransferred";
+  const EVENT_NAME_ENTER_MARKETS = "EnterMarkets";
+
+  const EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT = "CTokenMockBorrowBalanceCurrent";
+  const EVENT_NAME_MOCK_MINT_C_TOKEN = "CTokenMockMint";
+  const EVENT_NAME_MOCK_REDEEM = "CTokenMockRedeem";
+  const EVENT_NAME_MOCK_REDEEM_UNDERLYING = "CTokenMockRedeemUnderlying";
+  const EVENT_NAME_MOCK_REPAY_BORROW_BEHALF = "CTokenMockRepayBorrowBehalf";
+
+  const EVENT_NAME_MOCK_MINT = "ERC20MockMint";
+  const EVENT_NAME_MOCK_BURN = "ERC20MockBurn";
+
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_NEW_OWNER_IS_ZERO = "Ownable: new owner is the zero address";
+
+  const REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED = "AdminAlreadyConfigured";
+  const REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED = "UnauthorizedAdmin";
+  const REVERT_ERROR_IF_COMPOUND_COMPTROLLER_FAILURE = "CompoundComptrollerFailure";
+  const REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE = "CompoundMarketFailure";
+  const REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH = "InputArraysLengthMismatch";
+  const REVERT_ERROR_IF_MINT_FAILURE = "MintFailure";
+  const REVERT_ERROR_IF_OWNER_IS_UNCHANGED = "OwnerUnchanged";
+
+  let agentFactory: ContractFactory;
+  let comptrollerFactory: ContractFactory;
+  let cTokenFactory: ContractFactory;
+  let uTokenFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let admin: SignerWithAddress;
+  let user: SignerWithAddress;
+  let stranger: SignerWithAddress;
+
+  before(async () => {
+    [deployer, admin, user, stranger] = await ethers.getSigners();
+    agentFactory = await ethers.getContractFactory("CompoundAgent");
+    comptrollerFactory = await ethers.getContractFactory("ComptrollerMock");
+    cTokenFactory = await ethers.getContractFactory("CTokenMock");
+    uTokenFactory = await ethers.getContractFactory("ERC20MintableMock");
+  });
+
+  async function deployHelperContracts(): Promise<HelperContracts> {
+    const uToken = await uTokenFactory.deploy("ERC20 Test", "TEST");
+    await uToken.deployed();
+
+    const comptroller = await comptrollerFactory.deploy();
+    await comptroller.deployed();
+
+    const cToken = await cTokenFactory.deploy(comptroller.address, uToken.address);
+    await cToken.deployed();
+
+    return {
+      comptroller,
+      cToken,
+      uToken,
+    };
+  }
+
+  async function deployAllContracts(): Promise<AllContracts> {
+    const { comptroller, cToken, uToken } = await deployHelperContracts();
+    const agent = await upgrades.deployProxy(agentFactory, [cToken.address]);
+    await agent.deployed();
+
+    return {
+      agent,
+      comptroller,
+      cToken,
+      uToken,
+    };
+  }
+
+  async function beforeRepayTrustedBorrow(): Promise<AllContracts> {
+    const contracts = await deployAllContracts();
+    await proveTx(contracts.agent.configureAdmin(admin.address, true));
+    return contracts;
+  }
+
+  describe("Function 'initialize()'", () => {
+    it("Configures the contract as expected", async () => {
+      const { agent, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+
+      await expect(
+        agent.deployTransaction
+      ).to.emit(
+        comptroller,
+        EVENT_NAME_ENTER_MARKETS
+      ).withArgs(cToken.address, 1);
+
+      expect(await agent.owner()).to.eq(deployer.address);
+      expect(await agent.isAdmin(deployer.address)).to.eq(false);
+      expect(await agent.market()).to.eq(cToken.address);
+
+      const ownerApproval: BigNumber = await uToken.allowance(agent.address, deployer.address);
+      const marketApproval: BigNumber = await uToken.allowance(agent.address, cToken.address);
+      expect(ownerApproval).to.eq(ethers.constants.MaxUint256);
+      expect(marketApproval).to.eq(ethers.constants.MaxUint256);
+    });
+
+    it("Is reverted if it is called a second time", async () => {
+      const { agent, cToken } = await setUpFixture(deployAllContracts);
+      await expect(
+        agent.initialize(cToken.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("Is reverted if the 'enterMarkets()' function of the comptroller contract fails", async () => {
+      const { comptroller, cToken } = await deployHelperContracts();
+      await proveTx(comptroller.setEnterMarketsResult(COMPTROLLER_ENTER_MARKET_BAD_RESULT));
+      const uninitializedAgent = await upgrades.deployProxy(agentFactory, [], { initializer: false });
+
+      await expect(
+        uninitializedAgent.initialize(cToken.address)
+      ).to.revertedWithCustomError(
+        agentFactory, REVERT_ERROR_IF_COMPOUND_COMPTROLLER_FAILURE
+      ).withArgs(COMPTROLLER_ENTER_MARKET_BAD_RESULT);
+    });
+
+    it("Is reverted for the contract implementation if it is called even for the first time", async () => {
+      const agent = await agentFactory.deploy();
+      await agent.deployed();
+
+      await expect(
+        agent.initialize(ethers.constants.AddressZero)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+  });
+
+  describe("Function 'configureAdmin()'", () => {
+    async function checkExecutionOfConfigureAdmin(
+      params: {
+        agent: Contract,
+        newAdminStatus: boolean
+      }
+    ) {
+      const { agent, newAdminStatus } = params;
+      await expect(
+        agent.configureAdmin(admin.address, newAdminStatus)
+      ).to.emit(
+        agent,
+        EVENT_NAME_CONFIGURE_ADMIN
+      ).withArgs(
+        admin.address,
+        newAdminStatus
+      );
+      expect(await agent.isAdmin(admin.address)).to.eq(newAdminStatus);
+    }
+
+    it("Executes as expected and emits the correct event", async () => {
+      const { agent } = await setUpFixture(deployAllContracts);
+      await checkExecutionOfConfigureAdmin({ agent, newAdminStatus: true });
+      await checkExecutionOfConfigureAdmin({ agent, newAdminStatus: false });
+    });
+
+    it("Is reverted if is called not by the owner", async () => {
+      const { agent } = await setUpFixture(deployAllContracts);
+      await expect(
+        agent.connect(stranger).configureAdmin(admin.address, true)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if the new admin status equals the previously set one", async () => {
+      const { agent } = await setUpFixture(deployAllContracts);
+      let adminStatus = false;
+      expect(await agent.isAdmin(admin.address)).to.eq(adminStatus);
+
+      await expect(
+        agent.configureAdmin(admin.address, adminStatus)
+      ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED);
+
+      adminStatus = true;
+      await proveTx(agent.configureAdmin(admin.address, adminStatus));
+
+      await expect(
+        agent.configureAdmin(admin.address, adminStatus)
+      ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED);
+    });
+  });
+
+  describe("Function 'mint()'", () => {
+
+    describe("Executes as expected with the correspondent cToken function call if the token amount is", () => {
+      async function checkExecutionOfMint(params: { tokenAmount: number }) {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.mint(params.tokenAmount)
+        ).to.emit(
+          cToken,
+          EVENT_NAME_MOCK_MINT_C_TOKEN
+        ).withArgs(
+          params.tokenAmount
+        );
+      }
+
+      it("Nonzero", async () => {
+        await checkExecutionOfMint({ tokenAmount: TOKEN_AMOUNT_STUB });
+      });
+
+      it("Zero", async () => {
+        await checkExecutionOfMint({ tokenAmount: 0 });
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the owner", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.connect(stranger).mint(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("The contract is paused", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await proveTx(agent.setPauser(deployer.address));
+        await proveTx(agent.pause());
+        await expect(
+          agent.mint(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The correspondent cToken function fails", async () => {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await proveTx(cToken.setMintResult(MARKET_MINT_FUNCTION_BAD_RESULT));
+        await expect(
+          agent.mint(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_MINT_FUNCTION_BAD_RESULT);
+      });
+    });
+  });
+
+  describe("Function 'redeem()'", () => {
+    describe("Executes as expected with the correspondent cToken function call if the token amount is", () => {
+      async function checkExecutionOfRedeem(params: { tokenAmount: number }) {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.redeem(params.tokenAmount)
+        ).to.emit(
+          cToken,
+          EVENT_NAME_MOCK_REDEEM
+        ).withArgs(
+          params.tokenAmount
+        );
+      }
+
+      it("Nonzero", async () => {
+        await checkExecutionOfRedeem({ tokenAmount: TOKEN_AMOUNT_STUB });
+      });
+
+      it("Zero", async () => {
+        await checkExecutionOfRedeem({ tokenAmount: 0 });
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the owner", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.connect(stranger).redeem(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("The contract is paused", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await proveTx(agent.setPauser(deployer.address));
+        await proveTx(agent.pause());
+        await expect(
+          agent.redeem(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The correspondent cToken function call fails", async () => {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await proveTx(cToken.setRedeemResult(MARKET_REDEEM_FUNCTION_BAR_RESULT));
+        await expect(
+          agent.redeem(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REDEEM_FUNCTION_BAR_RESULT);
+      });
+    });
+  });
+
+  describe("Function 'redeemUnderlying()'", () => {
+    describe("Executes as expected with the correspondent cToken function call if the token amount is", () => {
+      async function checkExecutionOfRedeemUnderlying(params: { tokenAmount: number }) {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.redeemUnderlying(params.tokenAmount)
+        ).to.emit(
+          cToken,
+          EVENT_NAME_MOCK_REDEEM_UNDERLYING
+        ).withArgs(
+          params.tokenAmount
+        );
+      }
+
+      it("Nonzero", async () => {
+        await checkExecutionOfRedeemUnderlying({ tokenAmount: TOKEN_AMOUNT_STUB });
+      });
+
+      it("Zero", async () => {
+        await checkExecutionOfRedeemUnderlying({ tokenAmount: 0 });
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the owner", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.connect(stranger).redeemUnderlying(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("The contract is paused", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await proveTx(agent.setPauser(deployer.address));
+        await proveTx(agent.pause());
+        await expect(
+          agent.redeemUnderlying(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The correspondent cToken function fails", async () => {
+        const { agent, cToken } = await setUpFixture(deployAllContracts);
+        await proveTx(cToken.setRedeemUnderlyingResult(MARKET_REDEEM_UNDERLYING_BAD_RESULT));
+        await expect(
+          agent.redeemUnderlying(TOKEN_AMOUNT_STUB)
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REDEEM_UNDERLYING_BAD_RESULT);
+      });
+    });
+  });
+
+  describe("Function 'repayTrustedBorrow()'", () => {
+    describe("Executes as expected if the borrow is", () => {
+      async function checkExecutionOfRepayTrustedBorrow(
+        params: {
+          isBorrowDefaulted: boolean,
+          inputTokenAmount: BigNumber
+        }
+      ) {
+        const { agent, cToken, uToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        const { isBorrowDefaulted, inputTokenAmount } = params;
+        const isInputTokenAmountMaximum = inputTokenAmount === ethers.constants.MaxUint256;
+        const actualTokenAmount = isInputTokenAmountMaximum ? TOKEN_AMOUNT_STUB - 1 : inputTokenAmount;
+
+        if (isInputTokenAmountMaximum) {
+          await proveTx(cToken.setBorrowBalanceCurrentResult(actualTokenAmount));
+        }
+
+        const tx: TransactionResponse =
+          await agent.connect(admin).repayTrustedBorrow(user.address, inputTokenAmount, isBorrowDefaulted);
+
+        await expect(tx).to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW).withArgs(user.address, actualTokenAmount);
+        await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF).withArgs(user.address, actualTokenAmount);
+        await expect(tx).to.emit(uToken, EVENT_NAME_MOCK_MINT).withArgs(agent.address, actualTokenAmount);
+
+        if (isBorrowDefaulted) {
+          await expect(tx).to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW).withArgs(user.address, actualTokenAmount);
+          await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REDEEM_UNDERLYING).withArgs(actualTokenAmount);
+          await expect(tx).to.emit(uToken, EVENT_NAME_MOCK_BURN).withArgs(actualTokenAmount);
+        } else {
+          await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW);
+          await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_REDEEM_UNDERLYING);
+          await expect(tx).not.to.emit(uToken, EVENT_NAME_MOCK_BURN);
+        }
+
+        if (isInputTokenAmountMaximum) {
+          await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT).withArgs(user.address);
+        } else {
+          await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT);
+        }
+      }
+
+      describe("Defaulted and the token amount is", () => {
+        it("Nonzero and less than 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: true,
+            inputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB)
+          });
+        });
+
+        it("Equal to 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: true,
+            inputTokenAmount: ethers.constants.MaxUint256
+          });
+        });
+
+        it("Zero", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: true,
+            inputTokenAmount: ethers.constants.Zero
+          });
+        });
+      });
+
+      describe("Not defaulted and the token amount is", () => {
+        it("Nonzero and less than 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: false,
+            inputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB)
+          });
+        });
+
+        it("Equal to 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: false,
+            inputTokenAmount: ethers.constants.MaxUint256
+          });
+        });
+
+        it("Zero", async () => {
+          await checkExecutionOfRepayTrustedBorrow({
+            isBorrowDefaulted: false,
+            inputTokenAmount: ethers.constants.Zero
+          });
+        });
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the admin", async () => {
+        const { agent } = await setUpFixture(beforeRepayTrustedBorrow);
+        await expect(
+          agent.repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
+      });
+
+      it("The contract is paused", async () => {
+        const { agent } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(agent.setPauser(deployer.address));
+        await proveTx(agent.pause());
+        await expect(
+          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The 'mint()' function of the underlying token fails", async () => {
+        const { agent, uToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(uToken.disableMint());
+        await expect(
+          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_MINT_FAILURE);
+      });
+
+      it("The 'repayBorrowBehalf()' function of cToken fails", async () => {
+        const { agent, cToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(cToken.setRepayBorrowBehalfResult(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT));
+        await expect(
+          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT);
+      });
+
+      it("The 'redeemUnderlying()' function of cToken fails", async () => {
+        const { agent, cToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(cToken.setRedeemUnderlyingResult(MARKET_REDEEM_UNDERLYING_BAD_RESULT));
+        await expect(
+          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REDEEM_UNDERLYING_BAD_RESULT);
+      });
+    });
+  });
+
+  describe("Function 'repayTrustedBorrows()'", () => {
+    describe("Executes as expected if the input arrays are not empty and the last borrow is", () => {
+      async function checkExecutionOfRepayTrustedBorrows(
+        params: {
+          isLastBorrowDefaulted: boolean,
+          lastInputTokenAmount: BigNumber
+        }
+      ) {
+        const { agent, cToken, uToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        const { isLastBorrowDefaulted, lastInputTokenAmount } = params;
+        const isLastInputTokenAmountMaximum = lastInputTokenAmount === ethers.constants.MaxUint256;
+        let lastActualTokenAmount = isLastInputTokenAmountMaximum ? TOKEN_AMOUNT_STUB - 1 : lastInputTokenAmount;
+
+        if (isLastInputTokenAmountMaximum) {
+          await proveTx(cToken.setBorrowBalanceCurrentResult(lastActualTokenAmount));
+        }
+
+        const tx: TransactionResponse =
+          await agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB, lastInputTokenAmount],
+            [BORROW_IS_NOT_DEFAULTED, isLastBorrowDefaulted]
+          );
+
+        await expect(tx).to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW).withArgs(deployer.address, TOKEN_AMOUNT_STUB);
+        await expect(tx).to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW).withArgs(user.address, lastActualTokenAmount);
+        await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF)
+          .withArgs(deployer.address, TOKEN_AMOUNT_STUB);
+        await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF)
+          .withArgs(user.address, lastActualTokenAmount);
+        await expect(tx).to.emit(uToken, EVENT_NAME_MOCK_MINT).withArgs(agent.address, TOKEN_AMOUNT_STUB);
+        await expect(tx).to.emit(uToken, EVENT_NAME_MOCK_MINT).withArgs(agent.address, lastActualTokenAmount);
+
+        if (isLastBorrowDefaulted) {
+          await expect(tx).to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW)
+            .withArgs(user.address, lastActualTokenAmount);
+          await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REDEEM_UNDERLYING).withArgs(lastActualTokenAmount);
+          await expect(tx).to.emit(uToken, EVENT_NAME_MOCK_BURN).withArgs(lastActualTokenAmount);
+        } else {
+          await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW);
+          await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_REDEEM_UNDERLYING);
+          await expect(tx).not.to.emit(uToken, EVENT_NAME_MOCK_BURN);
+        }
+
+        if (isLastInputTokenAmountMaximum) {
+          await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT).withArgs(user.address);
+        } else {
+          await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT);
+        }
+      }
+
+      describe("Defaulted and the token amount of the last borrow is", () => {
+        it("Nonzero and less than 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: true,
+            lastInputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB + 1)
+          });
+        });
+
+        it("Equal to 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: true,
+            lastInputTokenAmount: ethers.constants.MaxUint256
+          });
+        });
+
+        it("Zero", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: true,
+            lastInputTokenAmount: ethers.constants.Zero
+          });
+        });
+      });
+
+      describe("Not defaulted and the token amount of the last borrow is", () => {
+        it("Nonzero and less than 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: false,
+            lastInputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB + 1)
+          });
+        });
+
+        it("Equal to 'type(uint256).max'", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: false,
+            lastInputTokenAmount: ethers.constants.MaxUint256
+          });
+        });
+
+        it("Zero", async () => {
+          await checkExecutionOfRepayTrustedBorrows({
+            isLastBorrowDefaulted: false,
+            lastInputTokenAmount: ethers.constants.Zero
+          });
+        });
+      });
+    });
+
+    describe("Executes as expected if the input arrays are empty", () => {
+      it("Without emitting any events", async () => {
+        const { agent, cToken, uToken } = await setUpFixture(beforeRepayTrustedBorrow);
+
+        const tx: TransactionResponse = await agent.connect(admin).repayTrustedBorrows([], [], []);
+        await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW);
+        await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW);
+        await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF);
+        await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_REDEEM_UNDERLYING);
+        await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT);
+        await expect(tx).not.to.emit(uToken, EVENT_NAME_MOCK_MINT);
+        await expect(tx).not.to.emit(uToken, EVENT_NAME_MOCK_BURN);
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the admin", async () => {
+        const { agent } = await setUpFixture(beforeRepayTrustedBorrow);
+        await expect(
+          agent.repayTrustedBorrows([], [], [])
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
+      });
+
+      it("The contract is paused", async () => {
+        const { agent } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(agent.setPauser(deployer.address));
+        await proveTx(agent.pause());
+        await expect(
+          agent.connect(admin).repayTrustedBorrows([], [], [])
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("The length of input arrays mismatches", async () => {
+        const { agent } = await setUpFixture(beforeRepayTrustedBorrow);
+
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address],
+            [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
+            [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH);
+
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB],
+            [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH);
+
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
+            [BORROW_IS_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH);
+      });
+
+      it("The 'mint()' function of the underlying token fails", async () => {
+        const { agent, uToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(uToken.disableMint());
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
+            [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_MINT_FAILURE);
+      });
+
+      it("The 'repayBorrowBehalf()' function of cToken fails", async () => {
+        const { agent, cToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(cToken.setRepayBorrowBehalfResult(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT));
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
+            [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT);
+      });
+
+      it("The 'redeemUnderlying()' function of cToken fails", async () => {
+        const { agent, cToken } = await setUpFixture(beforeRepayTrustedBorrow);
+        await proveTx(cToken.setRedeemUnderlyingResult(MARKET_REDEEM_UNDERLYING_BAD_RESULT));
+        await expect(
+          agent.connect(admin).repayTrustedBorrows(
+            [deployer.address, user.address],
+            [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
+            [BORROW_IS_NOT_DEFAULTED, BORROW_IS_DEFAULTED]
+          )
+        ).to.be.revertedWithCustomError(
+          agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
+        ).withArgs(MARKET_REDEEM_UNDERLYING_BAD_RESULT);
+      });
+    });
+  });
+
+  describe("Function 'transferOwnership()'", () => {
+    describe("Executes as expected and emits the correct event", () => {
+      it("If the new owner differs from the previously set one", async () => {
+        const { agent, uToken } = await setUpFixture(deployAllContracts);
+        const oldOwner: SignerWithAddress = deployer;
+        const newOwner: SignerWithAddress = user;
+
+        expect(await agent.owner()).to.eq(oldOwner.address);
+        expect(await uToken.allowance(agent.address, newOwner.address)).to.eq(0);
+        expect(await uToken.allowance(agent.address, oldOwner.address)).to.eq(ethers.constants.MaxUint256);
+
+        await expect(
+          agent.transferOwnership(newOwner.address)
+        ).to.emit(
+          agent, EVENT_NAME_OWNERSHIP_TRANSFERRED
+        ).withArgs(
+          oldOwner.address,
+          newOwner.address
+        );
+
+        expect(await agent.owner()).to.eq(newOwner.address);
+        expect(await uToken.allowance(agent.address, newOwner.address)).to.eq(ethers.constants.MaxUint256);
+        expect(await uToken.allowance(agent.address, oldOwner.address)).to.eq(0);
+      });
+    });
+
+    describe("Is reverted if", () => {
+      it("It is called not by the owner", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.connect(stranger).transferOwnership(user.address)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("The new owner address is zero", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.transferOwnership(ethers.constants.AddressZero)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_NEW_OWNER_IS_ZERO);
+      });
+
+      it("The new owner address is the same as the previously set one", async () => {
+        const { agent } = await setUpFixture(deployAllContracts);
+        await expect(
+          agent.transferOwnership(deployer.address)
+        ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_OWNER_IS_UNCHANGED);
+      });
+    });
+  });
+});

--- a/test/base/PausableExtUpgradeable.test.ts
+++ b/test/base/PausableExtUpgradeable.test.ts
@@ -1,0 +1,167 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'PausableExtUpgradeable'", async () => {
+  const EVENT_NAME_PAUSED = "Paused";
+  const EVENT_NAME_PAUSER_CHANGED = "PauserChanged";
+  const EVENT_NAME_UNPAUSED = "Unpaused";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_UNPAUSED = "Pausable: not paused";
+
+  const REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER = "UnauthorizedPauser";
+
+  let pausableExtMockFactory: ContractFactory;
+  let deployer: SignerWithAddress;
+  let pauser: SignerWithAddress;
+
+  before(async () => {
+    [deployer, pauser] = await ethers.getSigners();
+    pausableExtMockFactory = await ethers.getContractFactory("PausableExtUpgradeableMock");
+  });
+
+  async function deployContractUnderTest(): Promise<{ pausableExtMock: Contract }> {
+    const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
+    await pausableExtMock.deployed();
+    return { pausableExtMock };
+  }
+
+  async function deployAndConfigureContractUnderTest(): Promise<{ pausableExtMock: Contract }> {
+    const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+    await proveTx(pausableExtMock.setPauser(pauser.address));
+    return { pausableExtMock };
+  }
+
+  describe("Initializers", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      expect(await pausableExtMock.owner()).to.equal(deployer.address);
+      expect(await pausableExtMock.pauser()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      await expect(
+        pausableExtMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      await expect(
+        pausableExtMock.call_parent_init()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      await expect(
+        pausableExtMock.call_parent_init_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'setPauser()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the owner", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+
+      await expect(
+        pausableExtMock.setPauser(pauser.address)
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_PAUSER_CHANGED
+      ).withArgs(pauser.address);
+      expect(await pausableExtMock.pauser()).to.equal(pauser.address);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        pausableExtMock.setPauser(pauser.address)
+      ).not.to.emit(pausableExtMock, EVENT_NAME_PAUSER_CHANGED);
+    });
+
+    it("Is reverted if it is called not by the owner", async () => {
+      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      await expect(
+        pausableExtMock.connect(pauser).setPauser(pauser.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+  });
+
+  describe("Function 'pause()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      expect(await pausableExtMock.paused()).to.equal(false);
+
+      await expect(
+        pausableExtMock.connect(pauser).pause()
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_PAUSED
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(true);
+    });
+
+    it("Is reverted if it is called not by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      await expect(
+        pausableExtMock.pause()
+      ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
+    });
+
+    it("Is reverted if the contract is already paused", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      await proveTx(pausableExtMock.connect(pauser).pause());
+
+      await expect(
+        pausableExtMock.connect(pauser).pause()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_PAUSED);
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      await proveTx(pausableExtMock.connect(pauser).pause());
+
+      expect(await pausableExtMock.paused()).to.equal(true);
+      await expect(
+        pausableExtMock.connect(pauser).unpause()
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_UNPAUSED
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(false);
+    });
+
+    it("Is reverted if it is called not by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      await expect(
+        pausableExtMock.unpause()
+      ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
+    });
+
+    it("Is reverted if the contract is already unpaused", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      await expect(
+        pausableExtMock.connect(pauser).unpause()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_UNPAUSED);
+    });
+  });
+});


### PR DESCRIPTION
### Description of the contract
1. The `CompoundAgent`(`CA`) contract is used to organize the communication with our [implementation](https://github.com/cloudwalk/compound-protocol) of the Compound contract.
2. The contract is upgradeable and designed according to the relevant [section](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable) of the OpennZeppelin documentation.
3. The code of the contract is distributed among the following files:
    * the interface file in the `interfaces` directory that contains declarations of main functions and events of the contract;
    * the storage file that contains declarations of the storage variables of the contract if any is used;
    * the implementation file that contains logic of the contract.
4. The contract has special accounts with the following roles: the owner and the admin. There can be only one owner and several admins.
5. There are functions in the contracts that can be called only by an account with the appropriate role.
6. The owner is by default the account that deployed the contract. It can be changes through the special function of ownership transferring.
7. An admin can be configured through the `configureAdmin()` function that can be called only by the owner.


### Testing and coverage
The tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```
Coverage:
![compound-agent-coverage](https://user-images.githubusercontent.com/97302011/205856084-9329e347-6cde-4b71-bbe5-1e04a7b6ad3d.png)
