### PR TITLE
Extend CompoundAgent with new functions to mint on debt collection

### DIFF
--- a/contracts/CompoundAgentStorage.sol
+++ b/contracts/CompoundAgentStorage.sol
@@ -15,6 +15,15 @@ abstract contract CompoundAgentStorageV1 {
 }
 
 /**
+ * @title CompoundAgent storage version 2
+ * @author CloudWalk Inc.
+ */
+abstract contract CompoundAgentStorageV2 {
+    /// @dev The cap of mint-on-debt-collection operation in underlying tokens.
+    uint256 internal _mintOnDebtCollectionCap;
+}
+
+/**
  * @title CompoundAgent storage
  *
  * We are following Compound's approach of upgrading new contract implementations.
@@ -23,6 +32,6 @@ abstract contract CompoundAgentStorageV1 {
  * e.g. CompoundAgentStorage<versionNumber>, so finally it would look like
  * "contract CompoundAgentStorage is CompoundAgentStorageV1, CompoundAgentStorageV2".
  */
-abstract contract CompoundAgentStorage is CompoundAgentStorageV1 {
+abstract contract CompoundAgentStorage is CompoundAgentStorageV1, CompoundAgentStorageV2 {
 
 }

--- a/contracts/interfaces/ICompoundAgent.sol
+++ b/contracts/interfaces/ICompoundAgent.sol
@@ -24,6 +24,13 @@ interface ICompoundAgent {
      */
     event RepayDefaultedBorrow(address indexed account, uint256 burnAmount);
 
+    /**
+     * @dev Emitted when cTokens are minted due to debt collection.
+     * @param borrower The address of the borrower associated with the debt collection.
+     * @param mintAmount The amount of underlying asset tokens to supply.
+     */
+    event MintOnDebtCollection(address borrower, uint256 mintAmount);
+
     // -------------------- Functions -----------------------------------
 
     /**
@@ -83,6 +90,15 @@ interface ICompoundAgent {
     ) external;
 
     /**
+     * @dev Mints and supplies underlying asset tokens into the market due to debt collection.
+     * @param borrower The address of the borrower associated with the debt collection.
+     * @param mintAmount The amount of underlying asset tokens to mint and supply.
+     *
+     * Emits a {MintOnDebtCollection} event.
+     */
+    function mintOnDebtCollection(address borrower, uint256 mintAmount) external;
+
+    /**
      * @dev Checks if the account is configured as a contract administrator.
      */
     function isAdmin(address account) external view returns (bool);
@@ -91,4 +107,9 @@ interface ICompoundAgent {
      * @dev Returns the address of the market contract.
      */
     function market() external view returns (address);
+
+    /**
+     * @dev Returns the cap of mint-on-debt-collection operation in underlying tokens.
+     */
+    function mintOnDebtCollectionCap() external view returns (uint256);
 }


### PR DESCRIPTION
### Changes
1. The new function `mintOnDebtCollection()` has been added.
2. The new function mints the requested amount of underlaying tokens and supplies them to the Compound market receiving the appropriate amount of cTokens in exchange.
3. The new function can be called only by an account with the admin role.
4. The new function can't mint underlying tokens more than a configured cap during a single call.
5. To store the cap the new internal variable `_mintOnDebtCollectionCap` has been added.
6. To read the cap the new function `mintOnDebtCollectionCap()` has been added.
7. To change the cap the new function `setMintOnDebtCollectionCap()` has been added.
8. New state-change functions generate the appropriate events: 
* `event MintOnDebtCollection(address borrower, uint256 mintAmount)`;
* `event SetMintOnDebtCollectionCap(uint256 oldCap, uint256 newCap)`.
9. The following new errors have been added: 
* `error MintOnDebtCollectionCapExcess()`;
* `error MintOnDebtCollectionCapUnchanged()`.


### Test and coverage
The tests of the `CompoundAgent` has been updated according to new functions and event.
The tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```
Coverage: 100%. Detailed information can be found in the [previoud PR](https://github.com/cloudwalk/compound-periphery/pull/1).