### PR TITLE
Synchronize minor items with the "brlc-contracts" repo

### DIFF
--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -8,16 +8,13 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/securit
 /**
  * @title PausableExtUpgradeable base contract
  * @author CloudWalk Inc.
- * @dev Extends the {PausableUpgradeable} contract by adding the `pauser` role.
+ * @dev Extends the OpenZeppelin's {PausableUpgradeable} contract by adding the `pauser` account.
  *
- * This contract is used through inheritance. It introduces the `pauser` role that is allowed
- * to trigger paused/unpaused state of the contract that is inherited from this one.
- *
- * By default, the pauser is to the zero address. This can later be changed
- * by the contract owner with the {setPauser} function.
+ * This contract is used through inheritance. It introduces the `pauser` role that is allowed to
+ * trigger the paused or unpaused state of the contract that is inherited from this one.
  */
 abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradeable {
-    /// @dev The address of the pauser.
+    /// @dev The address of the pauser that is allowed to trigger the paused or unpaused state of the contract.
     address private _pauser;
 
     // -------------------- Events -----------------------------------
@@ -27,30 +24,10 @@ abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradea
 
     // -------------------- Errors -----------------------------------
 
-    /// @dev The transaction sender is not a pauser.
+    /// @dev The message sender is not a pauser.
     error UnauthorizedPauser(address account);
 
-    // -------------------- Functions --------------------------------
-
-    /**
-     * @dev The internal initializer of the upgradable contract.
-     *
-     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
-     */
-    function __PausableExt_init() internal onlyInitializing {
-        __Context_init_unchained();
-        __Ownable_init_unchained();
-        __Pausable_init_unchained();
-
-        __PausableExt_init_unchained();
-    }
-
-    /**
-     * @dev The internal unchained initializer of the upgradable contract.
-     *
-     * See {PausableExtUpgradeable-__PausableExt_init}.
-     */
-    function __PausableExt_init_unchained() internal onlyInitializing {}
+    // -------------------- Modifiers --------------------------------
 
     /**
      * @dev Throws if called by any account other than the pauser.
@@ -62,11 +39,48 @@ abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradea
         _;
     }
 
+    // -------------------- Functions --------------------------------
+
     /**
-     * @dev Returns the pauser address.
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
      */
-    function pauser() public view virtual returns (address) {
-        return _pauser;
+    function __PausableExt_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+
+        __PausableExt_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {PausableExtUpgradeable-__PausableExt_init}.
+     */
+    function __PausableExt_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Triggers the paused state of the contract.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function pause() external onlyPauser {
+        _pause();
+    }
+
+    /**
+     * @dev Triggers the unpaused state of the contract.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function unpause() external onlyPauser {
+        _unpause();
     }
 
     /**
@@ -87,28 +101,13 @@ abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradea
 
         _pauser = newPauser;
 
-        emit PauserChanged(_pauser);
+        emit PauserChanged(newPauser);
     }
 
     /**
-     * @dev See {PausableUpgradeable-pause}.
-     *
-     * Requirements:
-     *
-     * - Can only be called by the contract pauser.
+     * @dev Returns the pauser address.
      */
-    function pause() external onlyPauser {
-        _pause();
-    }
-
-    /**
-     * @dev See {PausableUpgradeable-unpause}.
-     *
-     * Requirements:
-     *
-     * - Can only be called by the contract pauser.
-     */
-    function unpause() external onlyPauser {
-        _unpause();
+    function pauser() public view virtual returns (address) {
+        return _pauser;
     }
 }

--- a/contracts/mock/base/PausableExtUpgradeableMock.sol
+++ b/contracts/mock/base/PausableExtUpgradeableMock.sol
@@ -11,27 +11,27 @@ import { PausableExtUpgradeable } from "../../base/PausableExtUpgradeable.sol";
  */
 contract PausableExtUpgradeableMock is PausableExtUpgradeable {
     /**
-     * @dev The initializer of the upgradable contract.
+     * @dev The initialize function of the upgradable contract.
      *
-     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
      */
     function initialize() public initializer {
         __PausableExt_init();
     }
 
     /**
-     * @dev Needed to check that the internal initializer of the ancestor contract
+     * @dev Needed to check that the initialize function of the ancestor contract
      * has the 'onlyInitializing' modifier.
      */
-    function call_parent_init() public {
+    function call_parent_initialize() public {
         __PausableExt_init();
     }
 
     /**
-     * @dev Needed to check that the internal unchained initializer of the ancestor contract
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
      * has the 'onlyInitializing' modifier.
      */
-    function call_parent_init_unchained() public {
+    function call_parent_initialize_unchained() public {
         __PausableExt_init_unchained();
     }
 }

--- a/test/base/PausableExtUpgradeable.test.ts
+++ b/test/base/PausableExtUpgradeable.test.ts
@@ -21,12 +21,11 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
   const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
-  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_PAUSED = "Pausable: paused";
-  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_UNPAUSED = "Pausable: not paused";
 
   const REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER = "UnauthorizedPauser";
 
   let pausableExtMockFactory: ContractFactory;
+
   let deployer: SignerWithAddress;
   let pauser: SignerWithAddress;
 
@@ -35,50 +34,54 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
     pausableExtMockFactory = await ethers.getContractFactory("PausableExtUpgradeableMock");
   });
 
-  async function deployContractUnderTest(): Promise<{ pausableExtMock: Contract }> {
+  async function deployPausableExtMock(): Promise<{ pausableExtMock: Contract }> {
     const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
     await pausableExtMock.deployed();
     return { pausableExtMock };
   }
 
-  async function deployAndConfigureContractUnderTest(): Promise<{ pausableExtMock: Contract }> {
-    const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+  async function deployAndConfigurePausableExtMock(): Promise<{ pausableExtMock: Contract }> {
+    const { pausableExtMock } = await deployPausableExtMock();
     await proveTx(pausableExtMock.setPauser(pauser.address));
     return { pausableExtMock };
   }
 
-  describe("Initializers", async () => {
+  describe("Function 'initialize()'", async () => {
     it("The external initializer configures the contract as expected", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+
       expect(await pausableExtMock.owner()).to.equal(deployer.address);
       expect(await pausableExtMock.pauser()).to.equal(ethers.constants.AddressZero);
+
+      // The initial contract state is unpaused
+      expect(await pausableExtMock.paused()).to.equal(false);
     });
 
     it("The external initializer is reverted if it is called a second time", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
       await expect(
         pausableExtMock.initialize()
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
     });
 
     it("The internal initializer is reverted if it is called outside the init process", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
       await expect(
-        pausableExtMock.call_parent_init()
+        pausableExtMock.call_parent_initialize()
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
     });
 
     it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
       await expect(
-        pausableExtMock.call_parent_init_unchained()
+        pausableExtMock.call_parent_initialize_unchained()
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
     });
   });
 
   describe("Function 'setPauser()'", async () => {
-    it("Executes as expected and emits the correct event if it is called by the owner", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
 
       await expect(
         pausableExtMock.setPauser(pauser.address)
@@ -95,7 +98,7 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
     });
 
     it("Is reverted if it is called not by the owner", async () => {
-      const { pausableExtMock } = await setUpFixture(deployContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
       await expect(
         pausableExtMock.connect(pauser).setPauser(pauser.address)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
@@ -103,9 +106,8 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
   });
 
   describe("Function 'pause()'", async () => {
-    it("Executes as expected and emits the correct event if it is called by the pauser", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
-      expect(await pausableExtMock.paused()).to.equal(false);
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
 
       await expect(
         pausableExtMock.connect(pauser).pause()
@@ -118,28 +120,18 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
     });
 
     it("Is reverted if it is called not by the pauser", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
       await expect(
         pausableExtMock.pause()
       ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
     });
-
-    it("Is reverted if the contract is already paused", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
-      await proveTx(pausableExtMock.connect(pauser).pause());
-
-      await expect(
-        pausableExtMock.connect(pauser).pause()
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_PAUSED);
-    });
   });
 
   describe("Function 'unpause()'", async () => {
-    it("Executes as expected and emits the correct event if it is called by the pauser", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
       await proveTx(pausableExtMock.connect(pauser).pause());
 
-      expect(await pausableExtMock.paused()).to.equal(true);
       await expect(
         pausableExtMock.connect(pauser).unpause()
       ).to.emit(
@@ -151,17 +143,10 @@ describe("Contract 'PausableExtUpgradeable'", async () => {
     });
 
     it("Is reverted if it is called not by the pauser", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
       await expect(
         pausableExtMock.unpause()
       ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
-    });
-
-    it("Is reverted if the contract is already unpaused", async () => {
-      const { pausableExtMock } = await setUpFixture(deployAndConfigureContractUnderTest);
-      await expect(
-        pausableExtMock.connect(pauser).unpause()
-      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_UNPAUSED);
     });
   });
 });


### PR DESCRIPTION
### Main changes
1. The following minor items of the `PausableExtUpgradeable` base contract and its tests have been synchronized with the [brlc-contracts](https://github.com/cloudwalk/brlc-contracts) repo:
    * Comments.
    * Names.
    * Code style and formatting.
    * Test approaches.
    * Other small code improvements.

### Testing and coverage
The tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```

Test coverage is 100%:
![image](https://user-images.githubusercontent.com/97302011/213422599-30ecf232-85de-4af0-8aed-a2b43ec8124f.png)
