### PR TITLE
Transfer tokens from the user's wallet in the process of repayment

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -397,6 +397,134 @@
           }
         }
       }
+    },
+    "195e4296855daa549acc8cf3eb4b70e3590c25030836334cb1d03a354a3de37d": {
+      "address": "0xB2c3341D9bB0Fe3B9c0A948370fac4f3117A1774",
+      "txHash": "0x4e3428e2a6d131cfa51024e4d236c93547d3660627addf970b9315336ea0f4e2",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:18"
+          },
+          {
+            "label": "_market",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "CompoundAgentStorageV1",
+            "src": "contracts\\CompoundAgentStorage.sol:11"
+          },
+          {
+            "label": "_admins",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "CompoundAgentStorageV1",
+            "src": "contracts\\CompoundAgentStorage.sol:14"
+          },
+          {
+            "label": "_mintOnDebtCollectionCap",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_uint256",
+            "contract": "CompoundAgentStorageV2",
+            "src": "contracts\\CompoundAgentStorage.sol:23"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -402,6 +402,134 @@
           }
         }
       }
+    },
+    "195e4296855daa549acc8cf3eb4b70e3590c25030836334cb1d03a354a3de37d": {
+      "address": "0x0C1C012C1074B57DECeBaEf996D4DAb4B37a92FC",
+      "txHash": "0xc698f14477bf58801559e695d3e70dde56dd98a0d92e7310291bf39286c22254",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:18"
+          },
+          {
+            "label": "_market",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "CompoundAgentStorageV1",
+            "src": "contracts\\CompoundAgentStorage.sol:11"
+          },
+          {
+            "label": "_admins",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "CompoundAgentStorageV1",
+            "src": "contracts\\CompoundAgentStorage.sol:14"
+          },
+          {
+            "label": "_mintOnDebtCollectionCap",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_uint256",
+            "contract": "CompoundAgentStorageV2",
+            "src": "contracts\\CompoundAgentStorage.sol:23"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/CompoundAgent.sol
+++ b/contracts/CompoundAgent.sol
@@ -55,6 +55,9 @@ contract CompoundAgent is
     /// @dev Token minting failed.
     error MintFailure();
 
+    /// @dev Token transferring failed.
+    error TransferFromFailure();
+
     /// @dev The length of the input arrays does not match.
     error InputArraysLengthMismatch();
 
@@ -196,6 +199,49 @@ contract CompoundAgent is
         uint256 result = ICToken(_market).redeemUnderlying(redeemAmount);
         if (result != 0) {
             revert CompoundMarketFailure(result);
+        }
+    }
+
+    /**
+     * @dev See {ICompoundAgent-repayTrustedBorrow}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     */
+    function repayTrustedBorrow(
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) external onlyAdmin whenNotPaused {
+        ICToken cToken = ICToken(_market);
+        _repayTrustedBorrow(cToken, cToken.underlying(), borrower, repayAmount, defaulted);
+    }
+
+    /**
+     * @dev See {ICompoundAgent-repayTrustedBorrows}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     */
+    function repayTrustedBorrows(
+        address[] calldata borrowers,
+        uint256[] calldata repayAmounts,
+        bool[] calldata defaulted
+    ) external onlyAdmin whenNotPaused {
+        uint256 len = borrowers.length;
+        if (len != repayAmounts.length || len != defaulted.length) {
+            revert InputArraysLengthMismatch();
+        }
+
+        ICToken cToken = ICToken(_market);
+        address uToken = cToken.underlying();
+
+        for (uint256 i = 0; i < len; ++i) {
+            _repayTrustedBorrow(cToken, uToken, borrowers[i], repayAmounts[i], defaulted[i]);
         }
     }
 
@@ -375,6 +421,31 @@ contract CompoundAgent is
      * @param repayAmount The amount of tokens to repay.
      * @param defaulted True if the borrow is defaulted.
      */
+    function _repayTrustedBorrow(
+        ICToken cToken,
+        address uToken,
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) internal {
+        uint256 repaidAmount = _transferFromAndRepay(cToken, IERC20Upgradeable(uToken), borrower, repayAmount);
+        if (defaulted) {
+            _redeemAndBurn(cToken, IERC20Mintable(uToken), borrower, repaidAmount);
+        }
+    }
+
+    /**
+     * @dev Repays a borrow belonging to a trusted borrower.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     * Emits a {RepayDefaultedBorrow} event in the case of a defaulted borrow.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @param defaulted True if the borrow is defaulted.
+     */
     function _mintAndRepayTrustedBorrow(
         ICToken cToken,
         IERC20Mintable uToken,
@@ -410,6 +481,38 @@ contract CompoundAgent is
 
         if (!uToken.mint(address(this), actualRepayAmount)) {
             revert MintFailure();
+        }
+
+        uint256 repayResult = cToken.repayBorrowBehalf(borrower, actualRepayAmount);
+        if (repayResult != 0) {
+            revert CompoundMarketFailure(repayResult);
+        }
+
+        emit RepayTrustedBorrow(borrower, actualRepayAmount);
+    }
+
+    /**
+     * @dev Transfers tokens and repays a borrow on behalf of a trusted borrower.
+     *
+     * Emits a {RepayTrustedBorrow} event.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower being repaid.
+     * @param repayAmount The amount of tokens to repay.
+     */
+    function _transferFromAndRepay(
+        ICToken cToken,
+        IERC20Upgradeable uToken,
+        address borrower,
+        uint256 repayAmount
+    ) internal returns (uint256 actualRepayAmount) {
+        actualRepayAmount = repayAmount == type(uint256).max
+            ? repayAmount = cToken.borrowBalanceCurrent(borrower)
+            : repayAmount;
+
+        if (!uToken.transferFrom(borrower, address(this), actualRepayAmount)) {
+            revert TransferFromFailure();
         }
 
         uint256 repayResult = cToken.repayBorrowBehalf(borrower, actualRepayAmount);

--- a/contracts/CompoundAgent.sol
+++ b/contracts/CompoundAgent.sol
@@ -207,14 +207,14 @@ contract CompoundAgent is
      * - The caller must be an admin.
      * - The contract must not be paused.
      */
-    function repayTrustedBorrow(
+    function mintAndRepayTrustedBorrow(
         address borrower,
         uint256 repayAmount,
         bool defaulted
     ) external onlyAdmin whenNotPaused {
         ICToken cToken = ICToken(_market);
         IERC20Mintable uToken = IERC20Mintable(cToken.underlying());
-        _repayTrustedBorrow(cToken, uToken, borrower, repayAmount, defaulted);
+        _mintAndRepayTrustedBorrow(cToken, uToken, borrower, repayAmount, defaulted);
     }
 
     /**
@@ -225,7 +225,7 @@ contract CompoundAgent is
      * - The caller must be an admin.
      * - The contract must not be paused.
      */
-    function repayTrustedBorrows(
+    function mintAndRepayTrustedBorrows(
         address[] calldata borrowers,
         uint256[] calldata repayAmounts,
         bool[] calldata defaulted
@@ -239,7 +239,7 @@ contract CompoundAgent is
         IERC20Mintable uToken = IERC20Mintable(cToken.underlying());
 
         for (uint256 i = 0; i < len; ++i) {
-            _repayTrustedBorrow(cToken, uToken, borrowers[i], repayAmounts[i], defaulted[i]);
+            _mintAndRepayTrustedBorrow(cToken, uToken, borrowers[i], repayAmounts[i], defaulted[i]);
         }
     }
 
@@ -375,7 +375,7 @@ contract CompoundAgent is
      * @param repayAmount The amount of tokens to repay.
      * @param defaulted True if the borrow is defaulted.
      */
-    function _repayTrustedBorrow(
+    function _mintAndRepayTrustedBorrow(
         ICToken cToken,
         IERC20Mintable uToken,
         address borrower,

--- a/contracts/mock/ERC20MintableMock.sol
+++ b/contracts/mock/ERC20MintableMock.sol
@@ -14,11 +14,17 @@ contract ERC20MintableMock is ERC20, IERC20Mintable {
     /// @dev The disable state of the `mint()` function.
     bool private _mintDisabled;
 
+    /// @dev The disable state of the `transferFrom()` function.
+    bool private _transferFromDisabled;
+
     /// @dev Emitted when the `mint()` function is executed. Contains the arguments of the function.
     event ERC20MockMint(address account, uint256 amount);
 
     /// @dev Emitted when the `burn()` function is executed. Contains the argument of the function.
     event ERC20MockBurn(uint256 amount);
+
+    /// @dev Emitted when the `transferFrom()` function is executed. Contains the argument of the function.
+    event ERC20MockTransferFrom(address sender, address recipient, uint256 amount);
 
     /// @dev Initializes the contract with the provided name and symbol of the token.
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
@@ -41,8 +47,25 @@ contract ERC20MintableMock is ERC20, IERC20Mintable {
         emit ERC20MockBurn(amount);
     }
 
+    /**
+     * @dev Simulates the call of the {ERC20-transferFrom} function with emitting the corresponding event.
+     * @param sender The account whose tokens are transferred.
+     * @param recipient The account who receives tokens.
+     * @param amount The amount of tokens to transfer.
+     * @return True if the `transferFrom()` function is not disabled.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public override returns (bool) {
+        emit ERC20MockTransferFrom(sender, recipient, amount);
+        return _transferFromDisabled ? false : true;
+    }
+
     /// @dev Disables the `mint()` function.
     function disableMint() external {
         _mintDisabled = true;
+    }
+
+    /// @dev Disables the `transferFrom()` function.
+    function disableTransferFrom() external {
+        _transferFromDisabled = true;
     }
 }

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -11,7 +11,8 @@
 ||| Market #3 | [0x55AAEA6481816bbb49cA26F85f8E8Da8f11dC50E](https://explorer.mainnet.cloudwalk.io/address/0x55AAEA6481816bbb49cA26F85f8E8Da8f11dC50E) |
 ||| Market #2 | [0x1eBB75FC503239067DcCE18d0227A5f7513EE840](https://explorer.mainnet.cloudwalk.io/address/0x1eBB75FC503239067DcCE18d0227A5f7513EE840) |
 ||| Market #1 | [0x4e14C88765FFFA7199345c049f3149feDf200124](https://explorer.mainnet.cloudwalk.io/address/0x4e14C88765FFFA7199345c049f3149feDf200124) |
-| 3 | CompoundAgent | Proxy implementation | [0xe998B68395494B789DeB45625f7dC0c04e7F7c64](https://explorer.mainnet.cloudwalk.io/address/0xe998B68395494B789DeB45625f7dC0c04e7F7c64) |
+| 3 | CompoundAgent | Proxy implementation | [0x0C1C012C1074B57DECeBaEf996D4DAb4B37a92FC](https://explorer.mainnet.cloudwalk.io/address/0x0C1C012C1074B57DECeBaEf996D4DAb4B37a92FC) |
+|||| <strike>[0xe998B68395494B789DeB45625f7dC0c04e7F7c64](https://explorer.mainnet.cloudwalk.io/address/0xe998B68395494B789DeB45625f7dC0c04e7F7c64)</strike> |
 |||| <strike>[0x792Da6FA32CEeEa688b981C2539eE7106bBBb6b6](https://explorer.mainnet.cloudwalk.io/address/0x792Da6FA32CEeEa688b981C2539eE7106bBBb6b6)</strike> |
 |||| <strike>[0x1E73292eAd7B8910198A255DA8B1F996a3C07974](https://explorer.mainnet.cloudwalk.io/address/0x1E73292eAd7B8910198A255DA8B1F996a3C07974)</strike> |
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -25,6 +25,7 @@
 ||| Market #3 | [0xfe6316368cb40870cC068667a2469035Ad8668aD](https://explorer.testnet.cloudwalk.io/address/0xfe6316368cb40870cC068667a2469035Ad8668aD) |
 ||| Market #2 | [0x146984904E85bD01B4DdbC9A6B648A1d52a3e1Ab](https://explorer.testnet.cloudwalk.io/address/0x146984904E85bD01B4DdbC9A6B648A1d52a3e1Ab) |
 ||| Market #1 | [0x957d570c0d1de32e7a3Ce4093e2E101B0B60DA39](https://explorer.testnet.cloudwalk.io/address/0x957d570c0d1de32e7a3Ce4093e2E101B0B60DA39) |
-| 3 | CompoundAgent | Proxy implementation | [0x0bbDA25E26bB4759e0b01f38507F99A03EFa0ef9](https://explorer.testnet.cloudwalk.io/address/0x0bbDA25E26bB4759e0b01f38507F99A03EFa0ef9) |
+| 3 | CompoundAgent | Proxy implementation | [0xB2c3341D9bB0Fe3B9c0A948370fac4f3117A1774](https://explorer.testnet.cloudwalk.io/address/0xB2c3341D9bB0Fe3B9c0A948370fac4f3117A1774) |
+|||| <strike>[0x0bbDA25E26bB4759e0b01f38507F99A03EFa0ef9](https://explorer.testnet.cloudwalk.io/address/0x0bbDA25E26bB4759e0b01f38507F99A03EFa0ef9)</strike> |
 |||| <strike>[0x3f7eC982aDD991d0C8c0253140998213fa753cf5](https://explorer.testnet.cloudwalk.io/address/0x3f7eC982aDD991d0C8c0253140998213fa753cf5)</strike> |
 |||| <strike>[0x70FC00929821a32108Bc18375B2DE286f301a74b](https://explorer.testnet.cloudwalk.io/address/0x70FC00929821a32108Bc18375B2DE286f301a74b)</strike> |

--- a/test/CompoundAgent.test.ts
+++ b/test/CompoundAgent.test.ts
@@ -399,9 +399,9 @@ describe("Contract 'CompoundAgent'", function () {
     });
   });
 
-  describe("Function 'repayTrustedBorrow()'", () => {
+  describe("Function 'mintAndRepayTrustedBorrow()'", () => {
     describe("Executes as expected if the borrow is", () => {
-      async function checkExecutionOfRepayTrustedBorrow(
+      async function checkExecutionOfMintAndRepayTrustedBorrow(
         params: {
           isBorrowDefaulted: boolean,
           inputTokenAmount: BigNumber
@@ -417,7 +417,7 @@ describe("Contract 'CompoundAgent'", function () {
         }
 
         const tx: TransactionResponse =
-          await agent.connect(admin).repayTrustedBorrow(user.address, inputTokenAmount, isBorrowDefaulted);
+          await agent.connect(admin).mintAndRepayTrustedBorrow(user.address, inputTokenAmount, isBorrowDefaulted);
 
         await expect(tx).to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW).withArgs(user.address, actualTokenAmount);
         await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF).withArgs(user.address, actualTokenAmount);
@@ -442,21 +442,21 @@ describe("Contract 'CompoundAgent'", function () {
 
       describe("Defaulted and the token amount is", () => {
         it("Nonzero and less than 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: true,
             inputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB)
           });
         });
 
         it("Equal to 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: true,
             inputTokenAmount: ethers.constants.MaxUint256
           });
         });
 
         it("Zero", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: true,
             inputTokenAmount: ethers.constants.Zero
           });
@@ -465,21 +465,21 @@ describe("Contract 'CompoundAgent'", function () {
 
       describe("Not defaulted and the token amount is", () => {
         it("Nonzero and less than 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: false,
             inputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB)
           });
         });
 
         it("Equal to 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: false,
             inputTokenAmount: ethers.constants.MaxUint256
           });
         });
 
         it("Zero", async () => {
-          await checkExecutionOfRepayTrustedBorrow({
+          await checkExecutionOfMintAndRepayTrustedBorrow({
             isBorrowDefaulted: false,
             inputTokenAmount: ethers.constants.Zero
           });
@@ -491,7 +491,7 @@ describe("Contract 'CompoundAgent'", function () {
       it("It is called not by the admin", async () => {
         const { agent } = await setUpFixture(deployAndConfigureAllContracts);
         await expect(
-          agent.repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+          agent.mintAndRepayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
         ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
       });
 
@@ -500,7 +500,7 @@ describe("Contract 'CompoundAgent'", function () {
         await proveTx(agent.setPauser(deployer.address));
         await proveTx(agent.pause());
         await expect(
-          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+          agent.connect(admin).mintAndRepayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
         ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
       });
 
@@ -508,7 +508,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, uToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(uToken.disableMint());
         await expect(
-          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
+          agent.connect(admin).mintAndRepayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
         ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_MINT_FAILURE);
       });
 
@@ -516,7 +516,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, cToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(cToken.setRepayBorrowBehalfResult(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT));
         await expect(
-          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
+          agent.connect(admin).mintAndRepayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_NOT_DEFAULTED)
         ).to.be.revertedWithCustomError(
           agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
         ).withArgs(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT);
@@ -526,7 +526,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, cToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(cToken.setRedeemUnderlyingResult(MARKET_REDEEM_UNDERLYING_BAD_RESULT));
         await expect(
-          agent.connect(admin).repayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
+          agent.connect(admin).mintAndRepayTrustedBorrow(user.address, TOKEN_AMOUNT_STUB, BORROW_IS_DEFAULTED)
         ).to.be.revertedWithCustomError(
           agent, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE
         ).withArgs(MARKET_REDEEM_UNDERLYING_BAD_RESULT);
@@ -534,9 +534,9 @@ describe("Contract 'CompoundAgent'", function () {
     });
   });
 
-  describe("Function 'repayTrustedBorrows()'", () => {
+  describe("Function 'mintAndRepayTrustedBorrows()'", () => {
     describe("Executes as expected if the input arrays are not empty and the last borrow is", () => {
-      async function checkExecutionOfRepayTrustedBorrows(
+      async function checkExecutionOfMintAndRepayTrustedBorrows(
         params: {
           isLastBorrowDefaulted: boolean,
           lastInputTokenAmount: BigNumber
@@ -552,7 +552,7 @@ describe("Contract 'CompoundAgent'", function () {
         }
 
         const tx: TransactionResponse =
-          await agent.connect(admin).repayTrustedBorrows(
+          await agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB, lastInputTokenAmount],
             [BORROW_IS_NOT_DEFAULTED, isLastBorrowDefaulted]
@@ -587,21 +587,21 @@ describe("Contract 'CompoundAgent'", function () {
 
       describe("Defaulted and the token amount of the last borrow is", () => {
         it("Nonzero and less than 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: true,
             lastInputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB + 1)
           });
         });
 
         it("Equal to 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: true,
             lastInputTokenAmount: ethers.constants.MaxUint256
           });
         });
 
         it("Zero", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: true,
             lastInputTokenAmount: ethers.constants.Zero
           });
@@ -610,21 +610,21 @@ describe("Contract 'CompoundAgent'", function () {
 
       describe("Not defaulted and the token amount of the last borrow is", () => {
         it("Nonzero and less than 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: false,
             lastInputTokenAmount: BigNumber.from(TOKEN_AMOUNT_STUB + 1)
           });
         });
 
         it("Equal to 'type(uint256).max'", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: false,
             lastInputTokenAmount: ethers.constants.MaxUint256
           });
         });
 
         it("Zero", async () => {
-          await checkExecutionOfRepayTrustedBorrows({
+          await checkExecutionOfMintAndRepayTrustedBorrows({
             isLastBorrowDefaulted: false,
             lastInputTokenAmount: ethers.constants.Zero
           });
@@ -636,7 +636,7 @@ describe("Contract 'CompoundAgent'", function () {
       it("Without emitting any events", async () => {
         const { agent, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
 
-        const tx: TransactionResponse = await agent.connect(admin).repayTrustedBorrows([], [], []);
+        const tx: TransactionResponse = await agent.connect(admin).mintAndRepayTrustedBorrows([], [], []);
         await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_TRUSTED_BORROW);
         await expect(tx).not.to.emit(agent, EVENT_NAME_REPAY_DEFAULTED_BORROW);
         await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF);
@@ -651,7 +651,7 @@ describe("Contract 'CompoundAgent'", function () {
       it("It is called not by the admin", async () => {
         const { agent } = await setUpFixture(deployAndConfigureAllContracts);
         await expect(
-          agent.repayTrustedBorrows([], [], [])
+          agent.mintAndRepayTrustedBorrows([], [], [])
         ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
       });
 
@@ -660,7 +660,7 @@ describe("Contract 'CompoundAgent'", function () {
         await proveTx(agent.setPauser(deployer.address));
         await proveTx(agent.pause());
         await expect(
-          agent.connect(admin).repayTrustedBorrows([], [], [])
+          agent.connect(admin).mintAndRepayTrustedBorrows([], [], [])
         ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
       });
 
@@ -668,7 +668,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent } = await setUpFixture(deployAndConfigureAllContracts);
 
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address],
             [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
             [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
@@ -676,7 +676,7 @@ describe("Contract 'CompoundAgent'", function () {
         ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH);
 
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB],
             [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
@@ -684,7 +684,7 @@ describe("Contract 'CompoundAgent'", function () {
         ).to.be.revertedWithCustomError(agent, REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH);
 
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
             [BORROW_IS_DEFAULTED]
@@ -696,7 +696,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, uToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(uToken.disableMint());
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
             [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
@@ -708,7 +708,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, cToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(cToken.setRepayBorrowBehalfResult(MARKET_REPAY_BORROW_BEHALF_BAD_RESULT));
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
             [BORROW_IS_DEFAULTED, BORROW_IS_NOT_DEFAULTED]
@@ -722,7 +722,7 @@ describe("Contract 'CompoundAgent'", function () {
         const { agent, cToken } = await setUpFixture(deployAndConfigureAllContracts);
         await proveTx(cToken.setRedeemUnderlyingResult(MARKET_REDEEM_UNDERLYING_BAD_RESULT));
         await expect(
-          agent.connect(admin).repayTrustedBorrows(
+          agent.connect(admin).mintAndRepayTrustedBorrows(
             [deployer.address, user.address],
             [TOKEN_AMOUNT_STUB, TOKEN_AMOUNT_STUB],
             [BORROW_IS_NOT_DEFAULTED, BORROW_IS_DEFAULTED]


### PR DESCRIPTION
### Changes
1. The existing `repayTrustedBorrow` and `repayTrustedBorrows` functions, which mint tokens in the process of repayment, have been renamed to `mintAndRepayTrustedBorrow` and `mintAndRepayTrustedBorrows`.
2. The new `repayTrustedBorrow` and `repayTrustedBorrows` functions, which transfer tokens from the user's wallet in the process of repayment, have been created.
3. The tests have been updated accordingly. 

### Testing and coverage
![test_coverage](https://user-images.githubusercontent.com/72256997/216609648-c21ce1d8-f8b7-4352-8a8c-fc865a41858d.png)


