### PR TITLE
Create CompoundRelayer contract

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -29,6 +29,11 @@
       "address": "0xE23dc96fAe16E0bf33F510459249dc2f4eE3B031",
       "txHash": "0xb58a7de84a68ae04d03ead8aed6115db9d6655961743e578f68601f7aa702e55",
       "kind": "transparent"
+    },
+    {
+      "address": "0xa9b796cCDbbbe6B0BDBf2A96E5cb484465482030",
+      "txHash": "0x5000f3fb3cb67d9c35e1a1aaf4f8737b2da0f36fdae29d3d9953d8667b1eb498",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -652,6 +657,139 @@
             "numberOfBytes": "1"
           }
         }
+      }
+    },
+    "f167d0c3d61fd25b60a4633ba773d68098866bb6d625d72f2fb29c975571681b": {
+      "address": "0x1545a591c75ABAf5116311c80Ec74205Ba19cbDD",
+      "txHash": "0x7e7695bf0f623b5ba999bdd4e3436a9b8d195396928cd8a9f5d42bd518affe3d",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_compoundPayer",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "CompoundRelayerStorage",
+            "src": "contracts\\CompoundRelayerStorage.sol:11"
+          },
+          {
+            "label": "_admins",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "CompoundRelayerStorage",
+            "src": "contracts\\CompoundRelayerStorage.sol:13"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "CompoundRelayerStorage",
+            "src": "contracts\\CompoundRelayerStorage.sol:19"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "50",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:18"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
       }
     }
   }

--- a/contracts/CompoundRelayer.sol
+++ b/contracts/CompoundRelayer.sol
@@ -130,13 +130,6 @@ contract CompoundRelayer is
      *
      */
     function enterMarket(address market) external onlyOwner {
-        address[] memory cTokens = new address[](1);
-        cTokens[0] = market;
-        uint256[] memory enterMarketResults = IComptroller(ICToken(market).comptroller()).enterMarkets(cTokens);
-        if (enterMarketResults[0] != 0) {
-            revert CompoundComptrollerFailure(enterMarketResults[0]);
-        }
-
         IERC20Upgradeable uToken = IERC20Upgradeable(ICToken(market).underlying());
         uToken.approve(market, type(uint256).max);
     }

--- a/contracts/CompoundRelayer.sol
+++ b/contracts/CompoundRelayer.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
+
+import { IERC20Mintable } from "./interfaces/IERC20Mintable.sol";
+import { ICToken } from "./interfaces/ICToken.sol";
+import { IComptroller } from "./interfaces/IComptroller.sol";
+
+import { CompoundRelayerStorage } from "./CompoundRelayerStorage.sol";
+import { ICompoundRelayer } from "./interfaces/ICompoundRelayer.sol";
+
+/**
+ * @title CompoundRelayer contract
+ * @author CloudWalk Inc.
+ * @dev Compound operations wrapper contract.
+ */
+contract CompoundRelayer is
+    CompoundRelayerStorage,
+    Initializable,
+    OwnableUpgradeable,
+    PausableExtUpgradeable,
+    ICompoundRelayer
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @dev Emitted when an admin account is configured.
+     * @param account The address of the admin account.
+     * @param newStatus The new status of the admin account.
+     */
+    event ConfigureAdmin(address indexed account, bool newStatus);
+
+    /**
+     * @dev Emitted when a defaulted borrow is repaid.
+     * @param borrower The address of the borrower.
+     * @param burnAmount The amount of tokens that has been burned.
+     */
+    event RepayDefaultedBorrow(address indexed borrower, uint256 burnAmount);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The provided compound payer address is invalid.
+    error CompoundPayerInvalidAddress();
+
+    /// @dev The provided compound payer account is already configured.
+    error CompoundPayerAlreadyConfigured();
+
+    /// @dev The provided admin account is already configured.
+    error AdminAlreadyConfigured();
+
+    /// @dev The transaction sender is not an admin.
+    error UnauthorizedAdmin();
+
+    /// @dev Token transferring failed.
+    error TransferFromFailure();
+
+    /// @dev The length of the input arrays does not match.
+    error InputArraysLengthMismatch();
+
+    /**
+     * @dev An error occurred on the Compound comptroller.
+     * @param compError The code of the error that occurred.
+     */
+    error CompoundComptrollerFailure(uint256 compError);
+
+    /**
+     * @dev An error occurred on the Compound market.
+     * @param compError The code of the error that occurred.
+     */
+    error CompoundMarketFailure(uint256 compError);
+
+    /// @dev The provided owner is the same as previously set one.
+    error OwnerUnchanged();
+
+    // -------------------- Modifiers -----------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the admin.
+     */
+    modifier onlyAdmin() {
+        if (!_admins[_msgSender()]) {
+            revert UnauthorizedAdmin();
+        }
+        _;
+    }
+
+    // -------------------- Functions -----------------------------------
+
+    /**
+     * @dev Constructor that prohibits the initialization of the implementation of the upgradable contract.
+     *
+     * See details
+     * https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+     *
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev The initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() external initializer {
+        __CompoundRelayer_init();
+    }
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See {CompoundRelayer-initialize}.
+     */
+    function __CompoundRelayer_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+        __PausableExt_init_unchained();
+
+        __CompoundRelayer_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {CompoundRelayer-initialize}.
+     */
+    function __CompoundRelayer_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev See {ICompoundRelayer-enterMarket}.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     *
+     */
+    function enterMarket(address market) external onlyOwner {
+        address[] memory cTokens = new address[](1);
+        cTokens[0] = market;
+        uint256[] memory enterMarketResults = IComptroller(ICToken(market).comptroller()).enterMarkets(cTokens);
+        if (enterMarketResults[0] != 0) {
+            revert CompoundComptrollerFailure(enterMarketResults[0]);
+        }
+
+        IERC20Upgradeable uToken = IERC20Upgradeable(ICToken(market).underlying());
+        uToken.approve(market, type(uint256).max);
+    }
+
+    /**
+     * @dev See {ICompoundRelayer-repayBorrowBehalf}.
+     */
+    function repayBorrowBehalf(
+        address market,
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) external onlyAdmin whenNotPaused {
+        ICToken cToken = ICToken(market);
+        _repayBorrowBehalf(cToken, cToken.underlying(), borrower, repayAmount, defaulted);
+    }
+
+    /**
+     * @dev See {ICompoundRelayer-repayBorrowBehalfBatch}.
+     */
+    function repayBorrowBehalfBatch(
+        Repayment[] calldata repayments
+    ) external onlyAdmin whenNotPaused {
+        uint256 len = repayments.length;
+        for (uint256 i = 0; i < len; ++i) {
+            ICToken cToken = ICToken(repayments[i].market);
+            address uToken = cToken.underlying();
+
+            _repayBorrowBehalf(cToken, uToken, repayments[i].borrower, repayments[i].amount, repayments[i].defaulted);
+        }
+    }
+
+    /**
+     * @dev Repays a borrow on behalf of this compound relayer.
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @param defaulted True if the borrow is defaulted.
+     */
+    function _repayBorrowBehalf(
+        ICToken cToken,
+        address uToken,
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) internal {
+        uint256 repaidAmount = _transferFromAndRepay(cToken, IERC20Upgradeable(uToken), borrower, repayAmount);
+        if (defaulted) {
+            _redeemAndBurn(cToken, IERC20Mintable(uToken), borrower, repaidAmount);
+        }
+    }
+
+    /**
+     * @dev Repays a borrow on behalf of this compound relayer.
+     *
+     * Emits a {RepayBorrowBehalf} event.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower being repaid.
+     * @param repayAmount The amount of tokens to repay.
+     */
+    function _transferFromAndRepay(
+        ICToken cToken,
+        IERC20Upgradeable uToken,
+        address borrower,
+        uint256 repayAmount
+    ) internal returns (uint256 actualRepayAmount) {
+        actualRepayAmount = repayAmount == type(uint256).max
+            ? repayAmount = cToken.borrowBalanceCurrent(borrower)
+            : repayAmount;
+
+        if (!uToken.transferFrom(_compoundPayer, address(this), actualRepayAmount)) {
+            revert TransferFromFailure();
+        }
+
+        uint256 repayResult = cToken.repayBorrowBehalf(borrower, actualRepayAmount);
+        if (repayResult != 0) {
+            revert CompoundMarketFailure(repayResult);
+        }
+
+        emit RepayBorrowBehalf(borrower, actualRepayAmount);
+    }
+
+    /**
+     * @dev Redeems and burns tokens when a defaulted borrow is being repaid.
+     *
+     * Emits a {RepayDefaultedBorrow} event.
+     *
+     * @param cToken The address of the market.
+     * @param uToken The address of the underlying token.
+     * @param borrower The address of the borrower being repaid.
+     * @param burnAmount The amount of tokens to burn.
+     */
+    function _redeemAndBurn(
+        ICToken cToken,
+        IERC20Mintable uToken,
+        address borrower,
+        uint256 burnAmount
+    ) internal {
+        uint256 redeemResult = cToken.redeemUnderlying(burnAmount);
+        if (redeemResult != 0) {
+            revert CompoundMarketFailure(redeemResult);
+        }
+
+        uToken.burn(burnAmount);
+
+        emit RepayDefaultedBorrow(borrower, burnAmount);
+    }
+
+    /**
+     * @dev Configures an admin.
+     *
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     * - The new status of the admin must defer from the previously set one.
+     *
+     * Emits a {ConfigureAdmin} event.
+     *
+     * @param account The address of the admin account.
+     * @param newStatus The new status of the admin account.
+     */
+    function configureAdmin(address account, bool newStatus) external onlyOwner {
+        if (_admins[account] == newStatus) {
+            revert AdminAlreadyConfigured();
+        }
+
+        _admins[account] = newStatus;
+
+        emit ConfigureAdmin(account, newStatus);
+    }
+
+    /**
+     * @dev See {ICompoundRelayer-configureCompoundPayer}.
+     * Requirements:
+     *
+     * - The caller must be an owner.
+     *
+     * Emits a {ConfigureCompoundPayer} event.
+     */
+    function configureCompoundPayer(address compoundPayer) external onlyOwner {
+        address oldCompoundPayer = _compoundPayer;
+        if (compoundPayer == address(0)) {
+            revert CompoundPayerInvalidAddress();
+        }
+
+        if (compoundPayer == oldCompoundPayer) {
+            revert CompoundPayerAlreadyConfigured();
+        }
+
+        _compoundPayer = compoundPayer;
+
+        emit ConfigureCompoundPayer(oldCompoundPayer, _compoundPayer);
+    }
+
+    /**
+     * @dev Withdraws ERC20 tokens locked up in the contract.
+     *
+     * Requirements:
+     *
+     * - The caller must be the owner
+     *
+     * @param token The address of the ERC20 token contract.
+     * @param to The address of the recipient of tokens.
+     * @param amount The amount of tokens to withdraw.
+     */
+    function rescueERC20(
+        address token,
+        address to,
+        uint256 amount
+    ) public onlyOwner {
+        IERC20Upgradeable(token).safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev See {ICompoundRelayer-compoundPayer}.
+     */
+    function compoundPayer() external view returns (address) {
+        return _compoundPayer;
+    }
+
+    /**
+     * @dev See {ICompoundRelayer-isAdmin}.
+     */
+    function isAdmin(address account) external view returns (bool) {
+        return _admins[account];
+    }
+}

--- a/contracts/CompoundRelayerStorage.sol
+++ b/contracts/CompoundRelayerStorage.sol
@@ -11,4 +11,10 @@ abstract contract CompoundRelayerStorage {
     address internal _compoundPayer;
     /// @dev The mapping of an admin status for a given address.
     mapping(address => bool) internal _admins;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[48] private __gap;
 }

--- a/contracts/CompoundRelayerStorage.sol
+++ b/contracts/CompoundRelayerStorage.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title CompoundRelayer storage
+ * @author CloudWalk Inc.
+ */
+abstract contract CompoundRelayerStorage {
+    /// @dev The compound payer account whose tokens are used to repay borrows.
+    address internal _compoundPayer;
+    /// @dev The mapping of an admin status for a given address.
+    mapping(address => bool) internal _admins;
+}

--- a/contracts/interfaces/ICompoundRelayer.sol
+++ b/contracts/interfaces/ICompoundRelayer.sol
@@ -13,7 +13,6 @@ interface ICompoundRelayer {
         address market;
         address borrower;
         uint256 amount;
-        bool defaulted;
     }
 
     // -------------------- Events -----------------------------------
@@ -64,13 +63,11 @@ interface ICompoundRelayer {
      * @param market The address of the market.
      * @param borrower The address of a borrower.
      * @param repayAmount The amount of tokens to repay.
-     * @param defaulted True if the borrow is defaulted.
      */
     function repayBorrowBehalf(
         address market,
         address borrower,
-        uint256 repayAmount,
-        bool defaulted
+        uint256 repayAmount
     ) external;
 
     /**

--- a/contracts/interfaces/ICompoundRelayer.sol
+++ b/contracts/interfaces/ICompoundRelayer.sol
@@ -8,8 +8,7 @@ pragma solidity 0.8.16;
  * @dev The interface of the Compound operations wrapper contract.
  */
 interface ICompoundRelayer {
-    // -------------------- Structs -----------------------------------
-    /// @dev Structure with data of a repayments.
+    /// @dev Structure with data of a repayment.
     struct Repayment {
         address market;
         address borrower;
@@ -33,13 +32,26 @@ interface ICompoundRelayer {
      */
     event ConfigureCompoundPayer(address indexed oldPayer, address indexed newPayer);
 
-    // -------------------- Functions -----------------------------------
+    // -------------------- Functions --------------------------------
 
     /**
      * @dev Proxy function to enter markets.
      * @param market The address of the market.
      */
     function enterMarket(address market) external;
+
+    /**
+     * @dev Configures an admin.
+     * @param account The address of the admin account.
+     * @param newStatus The new status of the admin account.
+     */
+    function configureAdmin(address account, bool newStatus) external;
+
+    /**
+     * @dev Configures the compound payer account whose tokens are used to repay borrows.
+     * @param newCompoundPayer The address of the new compound payer.
+     */
+    function configureCompoundPayer(address newCompoundPayer) external;
 
     /**
      * @dev Repays a borrow on behalf of this compound relayer.
@@ -69,17 +81,13 @@ interface ICompoundRelayer {
      * - The caller must be an admin.
      * - The contract must not be paused.
      *
-     * @param repayments structs of repayments data.
+     * @param repayments Structures with the data of the repayments.
      */
     function repayBorrowBehalfBatch(
         Repayment[] calldata repayments
     ) external;
 
-    /**
-     * @dev Configures the compound payer account whose tokens are used to repay borrows.
-     * @param compoundPayer The address of the new compound payer.
-     */
-    function configureCompoundPayer(address compoundPayer) external;
+    // -------------------- View functions ---------------------------
 
     /**
      * @dev Returns the compound payer address.

--- a/contracts/interfaces/ICompoundRelayer.sol
+++ b/contracts/interfaces/ICompoundRelayer.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title ICompoundRelayer interface
+ * @author CloudWalk Inc.
+ * @dev The interface of the Compound operations wrapper contract.
+ */
+interface ICompoundRelayer {
+    // -------------------- Structs -----------------------------------
+    /// @dev Structure with data of a repayments.
+    struct Repayment {
+        address market;
+        address borrower;
+        uint256 amount;
+        bool defaulted;
+    }
+
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @dev Emitted when a borrow is repaid on behalf of this compound relayer.
+     * @param borrower The address of the borrower.
+     * @param repayAmount The amount of tokens being repaid.
+     */
+    event RepayBorrowBehalf(address indexed borrower, uint256 repayAmount);
+
+    /**
+     * @dev Emitted when the payer account is configured.
+     * @param oldPayer The old compound payer address.
+     * @param newPayer The new compound payer address.
+     */
+    event ConfigureCompoundPayer(address indexed oldPayer, address indexed newPayer);
+
+    // -------------------- Functions -----------------------------------
+
+    /**
+     * @dev Proxy function to enter markets.
+     * @param market The address of the market.
+     */
+    function enterMarket(address market) external;
+
+    /**
+     * @dev Repays a borrow on behalf of this compound relayer.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     *
+     * @param market The address of the market.
+     * @param borrower The address of a borrower.
+     * @param repayAmount The amount of tokens to repay.
+     * @param defaulted True if the borrow is defaulted.
+     */
+    function repayBorrowBehalf(
+        address market,
+        address borrower,
+        uint256 repayAmount,
+        bool defaulted
+    ) external;
+
+    /**
+     * @dev Repays a batch of borrows on behalf of this compound relayer.
+     *
+     * Requirements:
+     *
+     * - The caller must be an admin.
+     * - The contract must not be paused.
+     *
+     * @param repayments structs of repayments data.
+     */
+    function repayBorrowBehalfBatch(
+        Repayment[] calldata repayments
+    ) external;
+
+    /**
+     * @dev Configures the compound payer account whose tokens are used to repay borrows.
+     * @param compoundPayer The address of the new compound payer.
+     */
+    function configureCompoundPayer(address compoundPayer) external;
+
+    /**
+     * @dev Returns the compound payer address.
+     */
+    function compoundPayer() external view returns (address);
+
+    /**
+     * @dev Checks if the account is configured as a contract administrator.
+     */
+    function isAdmin(address account) external view returns (bool);
+}

--- a/contracts/mock/ERC20MintableMock.sol
+++ b/contracts/mock/ERC20MintableMock.sol
@@ -35,6 +35,7 @@ contract ERC20MintableMock is ERC20, IERC20Mintable {
      * @return True if the `mint()` function is not disabled.
      */
     function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
         emit ERC20MockMint(account, amount);
         return _mintDisabled ? false : true;
     }

--- a/test/CompoundRelayer.test.ts
+++ b/test/CompoundRelayer.test.ts
@@ -1,0 +1,331 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../test-utils/eth";
+
+interface HelperContracts {
+  comptroller: Contract;
+  cToken: Contract;
+  uToken: Contract;
+}
+
+interface AllContracts {
+  agent: Contract;
+  relayer: Contract;
+  comptroller: Contract;
+  cToken: Contract;
+  uToken: Contract;
+}
+
+interface Repayment {
+  market: string;
+  borrower: string;
+  repayAmount: number;
+  defaulted: boolean;
+}
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'CompoundRelayer'", function () {
+  const TOKEN_AMOUNT_STUB = 123;
+  const BORROWER_ADDRESS_STUB = "0x0000000000000000000000000000000000000001";
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+  const MARKET_MINT_FUNCTION_BAD_RESULT = 12301;
+  const MARKET_REDEEM_FUNCTION_BAR_RESULT = 12302;
+  const MARKET_REDEEM_UNDERLYING_BAD_RESULT = 12303;
+  const MARKET_REPAY_BORROW_BEHALF_BAD_RESULT = 12304;
+  const COMPTROLLER_ENTER_MARKET_BAD_RESULT = 12305;
+
+  const BORROW_IS_DEFAULTED = true;
+  const BORROW_IS_NOT_DEFAULTED = false;
+
+  const EVENT_NAME_CONFIGURE_ADMIN = "ConfigureAdmin";
+  const EVENT_NAME_ENTER_MARKETS = "EnterMarkets";
+  const EVENT_NAME_MINT_ON_DEBT_COLLECTION = "MintOnDebtCollection";
+  const EVENT_NAME_OWNERSHIP_TRANSFERRED = "OwnershipTransferred";
+  const EVENT_NAME_REPAY_TRUSTED_BORROW = "RepayTrustedBorrow";
+
+  const EVENT_NAME_REPAY_BORROW_BEHALF = "RepayBorrowBehalf";
+
+  const EVENT_NAME_REPAY_DEFAULTED_BORROW = "RepayDefaultedBorrow";
+  const EVENT_NAME_SET_MINT_ON_DEBT_COLLECTION_CAP = "SetMintOnDebtCollectionCap";
+
+  const EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT = "CTokenMockBorrowBalanceCurrent";
+  const EVENT_NAME_MOCK_MINT_C_TOKEN = "CTokenMockMint";
+  const EVENT_NAME_MOCK_REDEEM = "CTokenMockRedeem";
+  const EVENT_NAME_MOCK_REDEEM_UNDERLYING = "CTokenMockRedeemUnderlying";
+  const EVENT_NAME_MOCK_REPAY_BORROW_BEHALF = "CTokenMockRepayBorrowBehalf";
+
+  const EVENT_NAME_MOCK_MINT = "ERC20MockMint";
+  const EVENT_NAME_MOCK_BURN = "ERC20MockBurn";
+  const EVENT_NAME_MOCK_TRANSFER_FROM = "ERC20MockTransferFrom";
+
+  const EVENT_NAME_CONFIGURE_COMPOUND_PAYER = "ConfigureCompoundPayer";
+
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_NEW_OWNER_IS_ZERO = "Ownable: new owner is the zero address";
+
+  const REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED = "AdminAlreadyConfigured";
+  const REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED = "UnauthorizedAdmin";
+  const REVERT_ERROR_IF_COMPOUND_COMPTROLLER_FAILURE = "CompoundComptrollerFailure";
+  const REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE = "CompoundMarketFailure";
+  const REVERT_ERROR_IF_INPUT_ARRAYS_LENGTH_MISMATCH = "InputArraysLengthMismatch";
+  const REVERT_ERROR_IF_MINT_FAILURE = "MintFailure";
+  const REVERT_ERROR_IF_TRANSFER_FROM_FAILURE = "TransferFromFailure";
+  const REVERT_ERROR_IF_MINT_ON_DEBT_COLLECTION_CAP_EXCESS = "MintOnDebtCollectionCapExcess";
+  const REVERT_ERROR_IF_MINT_ON_DEBT_COLLECTION_CAP_UNCHANGED = "MintOnDebtCollectionCapUnchanged";
+  const REVERT_ERROR_IF_OWNER_IS_UNCHANGED = "OwnerUnchanged";
+
+  // const MARKET_1_ADDRESS = ethers.utils.ripemd160("MARKET_1");
+
+
+  let agentFactory: ContractFactory;
+  let relayerFactory: ContractFactory;
+  let comptrollerFactory: ContractFactory;
+  let cTokenFactory: ContractFactory;
+  let uTokenFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let admin: SignerWithAddress;
+  let user: SignerWithAddress;
+  let stranger: SignerWithAddress;
+  let compoundPayer: SignerWithAddress;
+
+  before(async () => {
+    [deployer, admin, user, stranger, compoundPayer] = await ethers.getSigners();
+    agentFactory = await ethers.getContractFactory("CompoundAgent");
+    relayerFactory = await ethers.getContractFactory("CompoundRelayer");
+    comptrollerFactory = await ethers.getContractFactory("ComptrollerMock");
+    cTokenFactory = await ethers.getContractFactory("CTokenMock");
+    uTokenFactory = await ethers.getContractFactory("ERC20MintableMock");
+  });
+
+  async function deployHelperContracts(): Promise<HelperContracts> {
+    const uToken = await uTokenFactory.deploy("ERC20 Test", "TEST");
+    await uToken.deployed();
+
+    const comptroller = await comptrollerFactory.deploy();
+    await comptroller.deployed();
+
+    const cToken = await cTokenFactory.deploy(comptroller.address, uToken.address);
+    await cToken.deployed();
+
+    return {
+      comptroller,
+      cToken,
+      uToken
+    };
+  }
+
+  async function deployAllContracts(): Promise<AllContracts> {
+    const { comptroller, cToken, uToken } = await deployHelperContracts();
+    const agent = await upgrades.deployProxy(agentFactory, [cToken.address]);
+    const relayer = await upgrades.deployProxy(relayerFactory);
+    await agent.deployed();
+    await relayer.deployed();
+
+    return {
+      agent,
+      relayer,
+      comptroller,
+      cToken,
+      uToken
+    };
+  }
+
+  async function deployAndConfigureAllContracts(): Promise<AllContracts> {
+    const contracts = await deployAllContracts();
+    await proveTx(contracts.agent.configureAdmin(admin.address, true));
+    return contracts;
+  }
+
+  describe("Function 'initialize()'", () => {
+    it("Configures the contract as expected", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+
+      expect(await relayer.owner()).to.eq(deployer.address);
+      expect(await relayer.isAdmin(deployer.address)).to.eq(false);
+    });
+
+    it("Is reverted if it is called a second time", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      await expect(
+        relayer.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("Is reverted for the contract implementation if it is called even for the first time", async () => {
+      const relayer = await relayerFactory.deploy();
+      await relayer.deployed();
+
+      await expect(
+        relayer.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+  });
+
+  describe("Function 'configureAdmin()'", () => {
+    async function checkExecutionOfConfigureAdmin(params: { relayer: Contract; newAdminStatus: boolean }) {
+      const { relayer, newAdminStatus } = params;
+      await expect(relayer.configureAdmin(admin.address, newAdminStatus))
+        .to.emit(relayer, EVENT_NAME_CONFIGURE_ADMIN)
+        .withArgs(admin.address, newAdminStatus);
+      expect(await relayer.isAdmin(admin.address)).to.eq(newAdminStatus);
+    }
+
+    it("Executes as expected and emits the correct event", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      await checkExecutionOfConfigureAdmin({ relayer, newAdminStatus: true });
+      await checkExecutionOfConfigureAdmin({ relayer, newAdminStatus: false });
+    });
+
+    it("Is reverted if is called not by the owner", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      await expect(
+        relayer.connect(stranger).configureAdmin(admin.address, true)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if the new admin status equals the previously set one", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      let adminStatus = false;
+      expect(await relayer.isAdmin(admin.address)).to.eq(adminStatus);
+
+      await expect(
+        relayer.configureAdmin(admin.address, adminStatus)
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED);
+
+      adminStatus = true;
+      await proveTx(relayer.configureAdmin(admin.address, adminStatus));
+
+      await expect(
+        relayer.configureAdmin(admin.address, adminStatus)
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED);
+    });
+  });
+  //
+  describe("Function 'enterMarket()'", () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      await expect(relayer.enterMarket(cToken.address))
+        .to.emit(comptroller, EVENT_NAME_ENTER_MARKETS)
+        .withArgs(cToken.address, 1);
+    });
+  });
+
+  describe("Function 'configureCompoundPayer()'", () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+      await expect(relayer.configureCompoundPayer(compoundPayer.address))
+        .to.emit(relayer, EVENT_NAME_CONFIGURE_COMPOUND_PAYER)
+        .withArgs(ZERO_ADDRESS, compoundPayer.address);
+
+      expect(await relayer.compoundPayer()).to.eq(compoundPayer.address);
+    });
+  });
+
+  describe("Function 'rescueERC20()'", () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+
+      await proveTx(uToken.mint(relayer.address, 1000));
+      expect(await uToken.balanceOf(relayer.address)).to.eq(1000);
+
+      await proveTx(relayer.rescueERC20(uToken.address, admin.address, 1000));
+      expect(await uToken.balanceOf(admin.address)).to.eq(1000);
+    });
+  });
+  //
+  // ////////////////////////////////////////
+  describe("Function 'repayBorrowBehalf()'", () => {
+    describe("Executes as expected if the borrow is", () => {
+      async function checkExecutionOfRepayBorrowBehalf(params: {
+        borrower: string;
+        repayAmount: BigNumber;
+        defaulted: boolean;
+      }) {
+        const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+        const { borrower, repayAmount, defaulted } = params;
+
+        let market: string = cToken.address;
+        await proveTx(cToken.setBorrowBalanceCurrentResult(repayAmount));
+        await proveTx(relayer.configureAdmin(admin.address, true));
+        const tx: TransactionResponse = await relayer.connect(admin).repayBorrowBehalf(
+          market,
+          borrower,
+          repayAmount,
+          defaulted
+        );
+
+        await expect(tx)
+          .to.emit(relayer, EVENT_NAME_REPAY_BORROW_BEHALF)
+          .withArgs(borrower, repayAmount);
+
+        await expect(tx)
+          .to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF)
+          .withArgs(borrower, repayAmount);
+      }
+
+      describe("Not Defaulted and the token amount is", () => {
+        it("Nonzero", async () => {
+          await checkExecutionOfRepayBorrowBehalf({
+            borrower: user.address,
+            repayAmount: BigNumber.from(1000),
+            defaulted: false
+          });
+        });
+      });
+    });
+  });
+
+  describe("Function 'repayBorrowBehalfBatch()'", () => {
+    describe("Executes as expected if the borrow is", () => {
+      async function checkExecutionOfRepayBorrowBehalfBatch(params:Repayment[], cToken: Contract, relayer: Contract) {
+        let borrower = params[0].borrower;
+        let repayAmount = params[0].repayAmount;
+
+        // console.log(repayAmount.toBigInt());
+        console.log(borrower);
+        await proveTx(cToken.setBorrowBalanceCurrentResult(repayAmount));
+        await proveTx(relayer.configureAdmin(admin.address, true));
+        const tx: TransactionResponse = await relayer.connect(admin).repayBorrowBehalfBatch(params);
+
+        await expect(tx)
+          .to.emit(relayer, EVENT_NAME_REPAY_BORROW_BEHALF)
+          .withArgs(borrower, repayAmount);
+
+        await expect(tx)
+          .to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF)
+          .withArgs(borrower, repayAmount);
+      }
+
+      describe("Not Defaulted and the token amount is", () => {
+        it("Nonzero", async () => {
+          const { agent, relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
+          await checkExecutionOfRepayBorrowBehalfBatch(
+            [{
+              market: cToken.address,
+              borrower: user.address,
+              repayAmount: 1000,
+              defaulted: false
+            }],
+            cToken,
+            relayer
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/CompoundRelayer.test.ts
+++ b/test/CompoundRelayer.test.ts
@@ -35,6 +35,9 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
 
 describe("Contract 'CompoundRelayer'", function () {
   const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+  const TOKEN_AMOUNT_STUB = 124;
+  const MARKET_MINT_FUNCTION_BAD_RESULT = 12301;
+  const COMPTROLLER_ENTER_MARKET_BAD_RESULT = 12305;
 
   const EVENT_NAME_ENTER_MARKETS = "EnterMarkets";
   const EVENT_NAME_CONFIGURE_ADMIN = "ConfigureAdmin";
@@ -42,10 +45,19 @@ describe("Contract 'CompoundRelayer'", function () {
   const EVENT_NAME_MOCK_REPAY_BORROW_BEHALF = "CTokenMockRepayBorrowBehalf";
   const EVENT_NAME_MOCK_TRANSFER_FROM = "ERC20MockTransferFrom";
   const EVENT_NAME_CONFIGURE_COMPOUND_PAYER = "ConfigureCompoundPayer";
+  const EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT = "CTokenMockBorrowBalanceCurrent";
 
   const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+
   const REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED = "AdminAlreadyConfigured";
+  const REVERT_ERROR_IF_COMPOUND_COMPTROLLER_FAILURE = "CompoundComptrollerFailure";
+  const REVERT_ERROR_IF_COMPOUND_PAYER_INVALID_ADDRESS = "CompoundPayerInvalidAddress";
+  const REVERT_ERROR_IF_COMPOUND_PAYER_ALREADY_CONFIGURED = "CompoundPayerAlreadyConfigured";
+  const REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED = "UnauthorizedAdmin";
+  const REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE = "CompoundMarketFailure";
+  const REVERT_ERROR_IF_TRANSFER_FROM_FAILURE = "TransferFromFailure";
 
   let relayerFactory: ContractFactory;
   let comptrollerFactory: ContractFactory;
@@ -167,11 +179,11 @@ describe("Contract 'CompoundRelayer'", function () {
       ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_ADMIN_IS_ALREADY_CONFIGURED);
     });
   });
-  //
+
   describe("Function 'enterMarket()'", () => {
     it("Executes as expected and emits the correct event", async () => {
       const { relayer, comptroller, cToken } = await setUpFixture(deployAllContracts);
-      await expect(relayer.enterMarket(cToken.address))
+      await expect(await relayer.enterMarket(cToken.address))
         .to.emit(comptroller, EVENT_NAME_ENTER_MARKETS)
         .withArgs(cToken.address, 1);
     });
@@ -181,6 +193,14 @@ describe("Contract 'CompoundRelayer'", function () {
       await expect(
         relayer.connect(stranger).enterMarket(cToken.address)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if market is listed", async () => {
+      const { relayer, comptroller, cToken } = await setUpFixture(deployAllContracts);
+      await proveTx(comptroller.setEnterMarketsResult(COMPTROLLER_ENTER_MARKET_BAD_RESULT));
+      await expect(relayer.enterMarket(cToken.address))
+        .to.revertedWithCustomError(relayerFactory, REVERT_ERROR_IF_COMPOUND_COMPTROLLER_FAILURE)
+        .withArgs(COMPTROLLER_ENTER_MARKET_BAD_RESULT);
     });
   });
 
@@ -200,20 +220,35 @@ describe("Contract 'CompoundRelayer'", function () {
         relayer.connect(stranger).configureCompoundPayer(compoundPayer.address)
       ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
     });
+
+    it("Is reverted if compound payer address is zero", async () => {
+      const { relayer } = await setUpFixture(deployAllContracts);
+      await expect(
+        relayer.configureCompoundPayer(ZERO_ADDRESS)
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_COMPOUND_PAYER_INVALID_ADDRESS);
+    });
+
+    it("Is reverted if compound payer address is already configured", async () => {
+      const { relayer } = await setUpFixture(deployAllContracts);
+      await relayer.configureCompoundPayer(compoundPayer.address);
+
+      await expect(
+        relayer.configureCompoundPayer(compoundPayer.address)
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_COMPOUND_PAYER_ALREADY_CONFIGURED);
+    });
   });
 
   describe("Function 'rescueERC20()'", () => {
     it("Executes as expected and emits the correct event", async () => {
       const { relayer, comptroller, cToken, uToken } = await setUpFixture(deployAllContracts);
-      const tokenAmount = 1000;
-      await proveTx(uToken.mint(relayer.address, tokenAmount));
+      await proveTx(uToken.mint(relayer.address, TOKEN_AMOUNT_STUB));
 
       await expect(
-        relayer.rescueERC20(uToken.address, admin.address, tokenAmount)
+        relayer.rescueERC20(uToken.address, admin.address, TOKEN_AMOUNT_STUB)
       ).to.changeTokenBalances(
         uToken,
         [relayer, admin],
-        [-tokenAmount, +tokenAmount]
+        [-TOKEN_AMOUNT_STUB, +TOKEN_AMOUNT_STUB]
       );
     });
 
@@ -235,11 +270,16 @@ describe("Contract 'CompoundRelayer'", function () {
 
       let market: string = cToken.address;
       await proveTx(cToken.setBorrowBalanceCurrentResult(repayAmount));
+      const isInputTokenAmountMaximum = repayAmount === ethers.constants.MaxUint256;
       const tx: TransactionResponse = await relayer.connect(admin).repayBorrowBehalf(
         market,
         borrower,
         repayAmount
       );
+
+      if (isInputTokenAmountMaximum) {
+        await proveTx(cToken.setBorrowBalanceCurrentResult(repayAmount));
+      }
 
       await expect(tx)
         .to.emit(relayer, EVENT_NAME_REPAY_BORROW_BEHALF)
@@ -252,13 +292,86 @@ describe("Contract 'CompoundRelayer'", function () {
       await expect(tx)
         .to.emit(cToken, EVENT_NAME_MOCK_REPAY_BORROW_BEHALF)
         .withArgs(borrower, repayAmount);
+
+      if (isInputTokenAmountMaximum) {
+        await expect(tx).to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT).withArgs(user.address);
+      } else {
+        await expect(tx).not.to.emit(cToken, EVENT_NAME_MOCK_BORROW_BALANCE_CURRENT);
+      }
     }
 
-    it("Repays borrow on behalf as expected", async () => {
-      await checkExecutionOfRepayBorrowBehalf({
-        borrower: user.address,
-        repayAmount: BigNumber.from(1000)
+    describe("The token amount is", () => {
+      it("Nonzero and less than 'type(uint256).max'", async () => {
+        await checkExecutionOfRepayBorrowBehalf({
+          borrower: user.address,
+          repayAmount: BigNumber.from(TOKEN_AMOUNT_STUB)
+        });
       });
+
+      it("Equal to 'type(uint256).max'", async () => {
+        await checkExecutionOfRepayBorrowBehalf({
+          borrower: user.address,
+          repayAmount: ethers.constants.MaxUint256
+        });
+      });
+
+      it("Zero", async () => {
+        await checkExecutionOfRepayBorrowBehalf({
+          borrower: user.address,
+          repayAmount: ethers.constants.Zero
+        });
+      });
+    });
+
+    it("Revert If Is Not Admin", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+
+      await expect(
+        relayer.repayBorrowBehalf(
+          cToken.address,
+          user.address,
+          BigNumber.from(TOKEN_AMOUNT_STUB)
+        )
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
+    });
+
+    it("Revert If Contract Is Paused", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+      await proveTx(relayer.setPauser(deployer.address));
+      await proveTx(relayer.pause());
+      await expect(
+        relayer.connect(admin).repayBorrowBehalf(
+          cToken.address,
+          user.address,
+          BigNumber.from(TOKEN_AMOUNT_STUB)
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Revert If Contract Is Transfer From Failure", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+      await proveTx(uToken.disableTransferFrom());
+
+      await expect(
+        relayer.connect(admin).repayBorrowBehalf(
+          cToken.address,
+          user.address,
+          BigNumber.from(TOKEN_AMOUNT_STUB)
+        )
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_TRANSFER_FROM_FAILURE);
+    });
+
+    it("Revert If Contract Is Contract Market Failure", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+      cToken.setRepayBorrowBehalfResult(MARKET_MINT_FUNCTION_BAD_RESULT);
+      await expect(
+        relayer.connect(admin).repayBorrowBehalf(
+          cToken.address,
+          user.address,
+          BigNumber.from(TOKEN_AMOUNT_STUB)
+        )
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_COMPOUND_MARKET_FAILURE)
+        .withArgs(MARKET_MINT_FUNCTION_BAD_RESULT);
     });
   });
 
@@ -288,16 +401,52 @@ describe("Contract 'CompoundRelayer'", function () {
         .withArgs(borrower, repayAmount);
     }
 
+    function getParamsAsTuple(cToken: Contract) {
+      let repayments = [{
+        market: cToken.address,
+        borrower: user.address,
+        repayAmount: TOKEN_AMOUNT_STUB
+      }];
+      return repayments.map(
+        repayment =>
+          [repayment.market, repayment.borrower, repayment.repayAmount]
+      );
+    }
+
     it("Repays borrow on behalf as expected", async () => {
       const contracts: AllContracts = await setUpFixture(deployAndConfigureAllContracts);
       await checkExecutionOfRepayBorrowBehalfBatch(
-        [{
-          market: contracts.cToken.address,
-          borrower: user.address,
-          repayAmount: 1000
-        }],
+        [
+          {
+            market: contracts.cToken.address,
+            borrower: user.address,
+            repayAmount: TOKEN_AMOUNT_STUB / 2
+          },
+          {
+            market: contracts.cToken.address,
+            borrower: user.address,
+            repayAmount: TOKEN_AMOUNT_STUB / 2
+          }],
         contracts
       );
+    });
+
+    it("Revert If Is Not Admin", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+      const paramsAsArrayOfTuples = getParamsAsTuple(cToken);
+      await expect(
+        relayer.repayBorrowBehalfBatch(paramsAsArrayOfTuples)
+      ).to.be.revertedWithCustomError(relayer, REVERT_ERROR_IF_ADMIN_IS_UNAUTHORIZED);
+    });
+
+    it("Revert If Contract Is Paused", async () => {
+      const { relayer, cToken, uToken } = await setUpFixture(deployAndConfigureAllContracts);
+      const paramsAsArrayOfTuples = getParamsAsTuple(cToken);
+      await proveTx(relayer.setPauser(deployer.address));
+      await proveTx(relayer.pause());
+      await expect(
+        relayer.connect(admin).repayBorrowBehalfBatch(paramsAsArrayOfTuples)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
     });
   });
 });


### PR DESCRIPTION
## Description

The new `CompoundRelayer` contract has been developed. The contract is similar to the `CompoundAgent` one and allows to repay borrows made on the `Compound` (`cToken`) contract using tokens from a pre-configured address named `compoundPayer`. Only accounts with the `admin` role can call the repayment functions of the new contract.

## CompoundRelayer Main Features

1.  The function to assign the `admin` role to an account:
    ```solidity
    /**
     * @dev Configures an admin.
     * @param account The address of the admin account.
     * @param newStatus The new status of the admin account.
     */
    function configureAdmin(address account, bool newStatus) external onlyOwner {}    
    ```

2.  The function to configure the `compoundPayer` account:
    ```solidity
    /**
     * @dev Configures the compound payer account whose tokens are used to repay borrows.
     * @param newCompoundPayer The address of the new compound payer.
     */
    function configureCompoundPayer(address newCompoundPayer) external onlyOwner {}
    ```

3. The `repayBorrowBehalf()` function that is used to repay a single borrow:
   ```solidity
    /**
     * @dev Repays a borrow on behalf of this compound relayer.
     *
     * Requirements:
     *
     * - The caller must be an admin.
     * - The contract must not be paused.
     *
     * @param market The address of the market.
     * @param borrower The address of a borrower.
     * @param repayAmount The amount of tokens to repay.
     */
    function repayBorrowBehalf(
        address market,
        address borrower,
        uint256 repayAmount
    ) external onlyAdmin whenNotPaused {}
   ```

4.  The `repayBorrowBehalfBatch()` function that is used to repay multiple borrows at once (in a batch):
    ```solidity
    /// @dev Structure with data of a repayment.
    struct Repayment {
        address market;
        address borrower;
        uint256 amount;
    }
   
    /**
     * @dev Repays a batch of borrows on behalf of this compound relayer.
     *
     * Requirements:
     *
     * - The caller must be an admin.
     * - The contract must not be paused.
     *
     * @param repayments Structures with the data of the repayments.
     */
    function repayBorrowBehalfBatch(Repayment[] calldata repayments) external onlyAdmin whenNotPaused {}
    ```

## Deployment and configuration 

1. Deploy `CompoundRelayer` contract to the network.
3. Configure admin accounts using the `configureAdmin()` function.
4. Configure the `compoundPayer` account using the `configureCompoundPayer()` function.
5. Approve the `CompoundRelayer` contract on the underlying token contract using the `compoundPayer` account.
6. Transfer the needed amount of the underlying token to the `compoundPayer` account to make repayments possible.

## Sample scripts:

1.  The example script for a single repayment using the [Hardhat toolbox](https://hardhat.org/):
    ```javascript
    async function singleRepayment(contractAddress, adminAccount, repaymentStruct) {
      const constract = await ethers.getContractAt("CompoundRelayer", contractAddress);
      const tx = await constract.connect(adminAccount).repayBorrowBehalf(
        repaymentStruct.marketAddress,
        repaymentStruct.borrowerAddress,
        repaymentStruct.amount
      );
      await tx.wait();
    }
    ```

2. The example script for a batch of repayments using the [Hardhat toolbox](https://hardhat.org/):
    ```javascript
    async function singleRepayment(contractAddress, adminAccount, repaymentStructs) {
      const constract = await ethers.getContractAt("CompoundRelayer", contractAddress);
      const params = repaymentStructs.map(repaymentStruct => [
        repaymentStruct.marketAddress,
        repaymentStruct.borrowerAddress,
        repaymentStruct.amount
      ]);
      const tx = await constract.connect(adminAccount).repayBorrowBehalfBatch(params);
      await tx.wait();
    }
    ```

## Tests and coverage

| File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Lines |
| ---- | ---- | ---- | ---- | ---- | ---- |
| contracts/ | 98.18 | 93.75 | 97.44 | 98.63 |  |
| &nbsp;&nbsp;  CompoundAgent.sol | 97.44 | 93.33 | 96 | 98.06 | 329,330 |
| &nbsp;&nbsp;  CompoundAgentStorage.sol | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  CompoundRelayer.sol | 100 | 94.74 | 100 | 100 |  |
| &nbsp;&nbsp;  CompoundRelayerStorage.sol | 100 | 100 | 100 | 100 |  |
| contracts/base/ | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  PausableExtUpgradeable.sol | 100 | 100 | 100 | 100 |  |
| contracts/interfaces/ | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  ICToken.sol | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  ICompoundAgent.sol | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  ICompoundRelayer.sol | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  IComptroller.sol | 100 | 100 | 100 | 100 |  |
| &nbsp;&nbsp;  IERC20Mintable.sol | 100 | 100 | 100 | 100 |  |
| contracts/mock/ | 100 | 100 | 100 | 100 |  |
| contracts/mock/base/ | 100 | 100 | 100 | 100 |  |
| All files | 98.65 | 94.59 | 98.57 | 98.99 |  |